### PR TITLE
[CHK-1965] feat(audit): add `LoggedAction` monad

### DIFF
--- a/src/main/kotlin/it/pagopa/wallet/audit/LoggedAction.kt
+++ b/src/main/kotlin/it/pagopa/wallet/audit/LoggedAction.kt
@@ -1,0 +1,50 @@
+package it.pagopa.wallet.audit
+
+import it.pagopa.wallet.repositories.LoggingEventRepository
+import reactor.core.publisher.Mono
+
+data class LoggedAction<T : Any>(private val data: T, private val events: List<LoggingEvent>) {
+    companion object {
+        fun <T : Any> swap(loggedAction: LoggedAction<Mono<T>>): Mono<LoggedAction<T>> {
+            return loggedAction.data.map { LoggedAction(it, loggedAction.events) }
+        }
+
+        fun <T : Any> join(loggedAction: LoggedAction<LoggedAction<T>>): LoggedAction<T> {
+            return loggedAction.flatMap { it }
+        }
+    }
+
+    constructor(data: T, event: LoggingEvent) : this(data, listOf(event))
+
+    fun <R : Any> flatMap(action: (T) -> LoggedAction<R>): LoggedAction<R> {
+        val result = action(this.data)
+
+        return LoggedAction(result.data, this.events + result.events)
+    }
+
+    fun <R : Any> map(mapper: (T) -> R): LoggedAction<R> {
+        return LoggedAction(mapper(this.data), this.events)
+    }
+
+    fun saveEvents(repository: LoggingEventRepository): Mono<T> {
+        return repository.saveAll(this.events).then(Mono.just(this.data))
+    }
+}
+
+fun <T : Any> LoggedAction<Mono<T>>.swap(): Mono<LoggedAction<T>> {
+    return LoggedAction.swap(this)
+}
+
+fun <T : Any> LoggedAction<LoggedAction<T>>.join(): LoggedAction<T> {
+    return LoggedAction.join(this)
+}
+
+fun <T : Any, R : Any> Mono<LoggedAction<T>>.flatMapLogged(
+    f: (T) -> Mono<LoggedAction<R>>
+): Mono<LoggedAction<R>> {
+    return this.mapLogged(f).map { it.join() }
+}
+
+fun <T : Any, R : Any> Mono<LoggedAction<T>>.mapLogged(f: (T) -> Mono<R>): Mono<LoggedAction<R>> {
+    return this.flatMap { action -> action.map(f).swap() }
+}

--- a/src/main/kotlin/it/pagopa/wallet/audit/LoggingEvent.kt
+++ b/src/main/kotlin/it/pagopa/wallet/audit/LoggingEvent.kt
@@ -1,0 +1,12 @@
+package it.pagopa.wallet.audit
+
+import java.time.Instant
+import java.util.*
+import org.springframework.data.mongodb.core.mapping.Document
+
+@Document("wallet-log-events")
+sealed class LoggingEvent(val id: UUID, val createdAt: Instant) {
+    constructor() : this(UUID.randomUUID(), Instant.now())
+}
+
+data class WalletAddedEvent(val walletId: String) : LoggingEvent()

--- a/src/main/kotlin/it/pagopa/wallet/repositories/LoggingEventRepository.kt
+++ b/src/main/kotlin/it/pagopa/wallet/repositories/LoggingEventRepository.kt
@@ -1,0 +1,6 @@
+package it.pagopa.wallet.repositories
+
+import it.pagopa.wallet.audit.LoggingEvent
+import org.springframework.data.repository.reactive.ReactiveCrudRepository
+
+interface LoggingEventRepository : ReactiveCrudRepository<LoggingEvent, String>

--- a/src/test/kotlin/it/pagopa/wallet/audit/LoggedActionTests.kt
+++ b/src/test/kotlin/it/pagopa/wallet/audit/LoggedActionTests.kt
@@ -1,0 +1,84 @@
+package it.pagopa.wallet.audit
+
+import it.pagopa.wallet.repositories.LoggingEventRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+class LoggedActionTests {
+    val repository: LoggingEventRepository = mock()
+
+    fun saveIdWithLogging(id: String): Mono<LoggedAction<String>> {
+        return Mono.just(id).map { LoggedAction(it, WalletAddedEvent(it)) }
+    }
+
+    @Test
+    fun `saveEvents saves events correctly`() {
+        val walletId = "walletId"
+        val expectedSavedEvents = listOf(WalletAddedEvent(walletId))
+
+        given(repository.saveAll(expectedSavedEvents)).willReturn(Flux.empty())
+
+        val actualId = saveIdWithLogging(walletId).flatMap { it.saveEvents(repository) }.block()
+
+        assertEquals(walletId, actualId)
+
+        verify(repository, times(1)).saveAll(any<Iterable<LoggingEvent>>())
+    }
+
+    @Test
+    fun `map transforms inner value and keeps events the same`() {
+        val loggingEvent1 = WalletAddedEvent("walletId1")
+
+        val f = { LoggedAction("id1", loggingEvent1) }
+
+        val result = f().map(String::uppercase)
+        val expected = LoggedAction("ID1", loggingEvent1)
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `flatMap concatenates logging events`() {
+        val loggingEvent1 = WalletAddedEvent("walletId1")
+        val loggingEvent2 = WalletAddedEvent("walletId2")
+
+        val f = { LoggedAction("id1", loggingEvent1) }
+        val g = { LoggedAction("id2", loggingEvent2) }
+
+        val result = f().flatMap { g() }
+        val expected = LoggedAction("id2", listOf(loggingEvent1, loggingEvent2))
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `flatMapLogged concatenates events correctly`() {
+        val walletId1 = "walletId1"
+
+        val actual = saveIdWithLogging(walletId1).flatMapLogged { saveIdWithLogging(it) }.block()
+
+        val expected =
+            LoggedAction(
+                walletId1,
+                listOf(WalletAddedEvent(walletId1), WalletAddedEvent(walletId1))
+            )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `mapLogged maps data correctly`() {
+        val walletId1 = "walletId1"
+
+        val f = { id: String -> Mono.just(id.uppercase()) }
+
+        val actual = saveIdWithLogging(walletId1).mapLogged(f).block()
+
+        val expected = LoggedAction(walletId1.uppercase(), listOf(WalletAddedEvent(walletId1)))
+
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
 * add `LoggedAction` monad to compose functions with embedded audit events

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This PR adds a `LoggedAction<T>` monad.
Inside this monad there is  a `T` value along a list of `LoggingEvent`s.
Composition of `LoggedAction`s through `flatMap` merges the lists of `LoggingEvents`.
Additonally, a `flatMapLogged` extension function is added to `Mono<LoggedAction<T>>` to allow easy composition with functions that return the same type.

An operation called `saveEvents` allows one to unwrap the inner value of a `LoggedAction`

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

Unit tests

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
