### PR TITLE
[CHK-2125] add wallet id to the response

### DIFF
--- a/api-spec/wallet-api.yaml
+++ b/api-spec/wallet-api.yaml
@@ -555,6 +555,8 @@ components:
       type: object
       description: Wallet creation response
       properties:
+        walletId:
+          $ref: '#/components/schemas/WalletId'
         redirectUrl:
           type: string
           format: url
@@ -563,6 +565,7 @@ components:
             payment instrument information with walletId and useDiagnosticTracing as query param
           example: http://localhost/inputPage?walletId=123&useDiagnosticTracing=true
       required:
+        - walletId
         - redirectUrl
     WalletInfo:
       type: object

--- a/src/main/kotlin/it/pagopa/wallet/controllers/WalletController.kt
+++ b/src/main/kotlin/it/pagopa/wallet/controllers/WalletController.kt
@@ -50,6 +50,7 @@ class WalletController(
             }
             .map {
                 WalletCreateResponseDto()
+                    .walletId(it.first)
                     .redirectUrl(
                         UriComponentsBuilder.fromUri(webviewPaymentWalletUrl.toURL().toURI())
                             .fragment("walletId=${it.first}&useDiagnosticTracing=${it.second}")

--- a/src/test/kotlin/it/pagopa/wallet/controllers/WalletControllerTest.kt
+++ b/src/test/kotlin/it/pagopa/wallet/controllers/WalletControllerTest.kt
@@ -52,13 +52,15 @@ class WalletControllerTest {
             .serializationInclusion(JsonInclude.Include.NON_NULL)
             .build()
 
+    private val webviewPaymentUrl = URI.create("https://dev.payment-wallet.pagopa.it/onboarding")
+
     @BeforeEach
     fun beforeTest() {
         walletController =
             WalletController(
                 walletService,
                 loggingEventRepository,
-                URI.create("https://dev.payment-wallet.pagopa.it/onboarding"),
+                webviewPaymentUrl,
                 uniqueIdUtils
             )
 
@@ -87,6 +89,16 @@ class WalletControllerTest {
             .exchange()
             .expectStatus()
             .isCreated
+            .expectBody()
+            .json(
+                objectMapper.writeValueAsString(
+                    WalletCreateResponseDto()
+                        .walletId(WALLET_DOMAIN.id.value)
+                        .redirectUrl(
+                            "$webviewPaymentUrl#walletId=${WALLET_DOMAIN.id.value}&useDiagnosticTracing=${WalletTestUtils.CREATE_WALLET_REQUEST.useDiagnosticTracing}"
+                        )
+                )
+            )
     }
 
     @Test


### PR DESCRIPTION
Add the walletId to the walleCreationResponse

#### List of Changes

1. Add the walletId to walletCreationResponse to be used from the apim policy to generate the jwt token 

#### Motivation and Context

Enable jwt security by apim policy

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
