### PR TITLE
[CHK-2177] refactor(api): move `PATCH /wallet/{id}` -> `PUT /wallet/{id}/services`

### DIFF
--- a/api-spec/wallet-api.yaml
+++ b/api-spec/wallet-api.yaml
@@ -151,14 +151,15 @@ paths:
           description: Wallet not found
         '504':
           description: Timeout serving request
-    patch:
+  /wallets/{walletId}/services:
+    post:
       tags:
         - wallets
-      summary: Partial wallet update
-      description: Update wallet partially
-      operationId: patchWalletById
+      summary: Update wallet services and their status
+      description: Update wallet services
+      operationId: updateWalletServicesById
       requestBody:
-        description: Create a new wallet
+        description: Update wallet services for the specified wallet
         content:
           application/json:
             schema:
@@ -689,8 +690,6 @@ components:
     WalletPatchRequest:
       type: object
       description: Wallet update request
-      items:
-        $ref: '#/components/schemas/PatchService'
       properties:
         services:
           type: array

--- a/api-spec/wallet-api.yaml
+++ b/api-spec/wallet-api.yaml
@@ -152,7 +152,7 @@ paths:
         '504':
           description: Timeout serving request
   /wallets/{walletId}/services:
-    post:
+    put:
       tags:
         - wallets
       summary: Update wallet services and their status
@@ -163,7 +163,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/WalletPatchRequest'
+              $ref: '#/components/schemas/WalletServiceUpdateRequest'
       parameters:
         - name: walletId
           in: path
@@ -174,6 +174,14 @@ paths:
       responses:
         '204':
           description: Wallet updated successfully
+        '409':
+          description: |
+           Wallet request is inconsistent with global service status
+           (e.g. the user requested a service to be enabled but the service has a global status of disabled)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WalletServicesPartialUpdate"
         '400':
           description: Invalid input id
           content:
@@ -457,7 +465,7 @@ paths:
       description: Set service status
       operationId: setServiceStatus
       requestBody:
-        description: Set service satus
+        description: Set service status
         content:
           application/json:
             schema:
@@ -576,6 +584,25 @@ components:
         redirectUrl:
           type: string
           description: redirect url in order to continue verify.
+    WalletServicesPartialUpdate:
+      type: object
+      description: Response for wallet services partial update due to status conflicts
+      properties:
+        updatedServices:
+          type: array
+          items:
+            $ref: "#/components/schemas/WalletService"
+        failedServices:
+          type: array
+          items:
+            $ref: "#/components/schemas/Service"
+      example:
+        updatedServices:
+          - name: "PAGOPA"
+            status: "ENABLED"
+        failedServices:
+          - name: "PARI"
+            status: "DISABLED"
     ServiceName:
       type: string
       description: Enumeration of services
@@ -596,14 +623,14 @@ components:
       description: Service identifier
       type: string
       format: uuid
-    PatchService:
+    WalletService:
       type: object
       properties:
         name:
           $ref: '#/components/schemas/ServiceName'
         status:
-          $ref: '#/components/schemas/ServicePatchStatus'
-    ServicePatchStatus:
+          $ref: '#/components/schemas/WalletServiceStatus'
+    WalletServiceStatus:
       type: string
       description: Enumeration of wallet statuses
       enum:
@@ -687,7 +714,7 @@ components:
         - type
         - abi
         - maskedEmail
-    WalletPatchRequest:
+    WalletServiceUpdateRequest:
       type: object
       description: Wallet update request
       properties:
@@ -695,7 +722,7 @@ components:
           type: array
           description: List of services to update
           items:
-            $ref: '#/components/schemas/PatchService'
+            $ref: '#/components/schemas/WalletService'
     WalletCreateRequest:
       type: object
       description: Wallet creation request

--- a/src/main/kotlin/it/pagopa/wallet/controllers/WalletController.kt
+++ b/src/main/kotlin/it/pagopa/wallet/controllers/WalletController.kt
@@ -19,8 +19,8 @@ import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ServerWebExchange
 import org.springframework.web.util.UriComponentsBuilder
-import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.toFlux
 
 @RestController
 @Slf4j
@@ -172,13 +172,14 @@ class WalletController(
      * @formatter:on
      */
     @SuppressWarnings("kotlin:S6508")
-    override fun patchWalletById(
+    override fun updateWalletServicesById(
         walletId: UUID,
-        patchServiceDto: Flux<PatchServiceDto>,
+        patchServiceDto: Mono<WalletPatchRequestDto>,
         exchange: ServerWebExchange
     ): Mono<ResponseEntity<Void>> {
 
         return patchServiceDto
+            .flatMapMany { it.services.toFlux() }
             .flatMap {
                 walletService.patchWallet(
                     walletId,

--- a/src/main/kotlin/it/pagopa/wallet/controllers/WalletController.kt
+++ b/src/main/kotlin/it/pagopa/wallet/controllers/WalletController.kt
@@ -6,6 +6,7 @@ import it.pagopa.wallet.domain.services.ServiceName
 import it.pagopa.wallet.domain.services.ServiceStatus
 import it.pagopa.wallet.domain.wallets.WalletId
 import it.pagopa.wallet.exception.WalletSecurityTokenNotFoundException
+import it.pagopa.wallet.exception.WalletServiceStatusConflictException
 import it.pagopa.wallet.repositories.LoggingEventRepository
 import it.pagopa.wallet.services.WalletService
 import java.net.URI
@@ -14,13 +15,14 @@ import kotlinx.coroutines.reactor.mono
 import lombok.extern.slf4j.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ServerWebExchange
 import org.springframework.web.util.UriComponentsBuilder
 import reactor.core.publisher.Mono
-import reactor.kotlin.core.publisher.toFlux
 
 @RestController
 @Slf4j
@@ -174,20 +176,32 @@ class WalletController(
     @SuppressWarnings("kotlin:S6508")
     override fun updateWalletServicesById(
         walletId: UUID,
-        patchServiceDto: Mono<WalletPatchRequestDto>,
+        patchServiceDto: Mono<WalletServiceUpdateRequestDto>,
         exchange: ServerWebExchange
     ): Mono<ResponseEntity<Void>> {
-
         return patchServiceDto
-            .flatMapMany { it.services.toFlux() }
-            .flatMap {
-                walletService.patchWallet(
+            .map { it.services }
+            .flatMap { requestedServices ->
+                walletService.updateWalletServices(
                     walletId,
-                    Pair(ServiceName(it.name.name), ServiceStatus.valueOf(it.status.value))
+                    requestedServices.map {
+                        Pair(ServiceName(it.name.name), ServiceStatus.valueOf(it.status.value))
+                    }
                 )
             }
             .flatMap { it.saveEvents(loggingEventRepository) }
-            .collectList()
+            .flatMap {
+                if (it.servicesWithUpdateFailed.isNotEmpty()) {
+                    return@flatMap Mono.error(
+                        WalletServiceStatusConflictException(
+                            it.successfullyUpdatedServices,
+                            it.servicesWithUpdateFailed
+                        )
+                    )
+                } else {
+                    return@flatMap Mono.just(it)
+                }
+            }
             .map { ResponseEntity.noContent().build() }
     }
 
@@ -213,5 +227,28 @@ class WalletController(
                 .filter { header: String -> header.startsWith("Bearer ") }
                 .map { header: String -> header.substring("Bearer ".length) }
         )
+    }
+
+    @ExceptionHandler(WalletServiceStatusConflictException::class)
+    fun walletServiceStatusConflictExceptionHandler(
+        exception: WalletServiceStatusConflictException
+    ): ResponseEntity<WalletServicesPartialUpdateDto> {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+            .body(
+                WalletServicesPartialUpdateDto().apply {
+                    updatedServices =
+                        exception.updatedServices.map {
+                            WalletServiceDto()
+                                .name(ServiceNameDto.valueOf(it.key.name))
+                                .status(WalletServiceStatusDto.valueOf(it.value.name))
+                        }
+                    failedServices =
+                        exception.failedServices.map {
+                            ServiceDto()
+                                .name(ServiceNameDto.valueOf(it.key.name))
+                                .status(ServiceStatusDto.valueOf(it.value.name))
+                        }
+                }
+            )
     }
 }

--- a/src/main/kotlin/it/pagopa/wallet/documents/wallets/Wallet.kt
+++ b/src/main/kotlin/it/pagopa/wallet/documents/wallets/Wallet.kt
@@ -28,7 +28,6 @@ data class Wallet(
     @CreatedDate var creationDate: Instant,
     @LastModifiedDate var updateDate: Instant
 ) {
-
     fun toDomain(): Wallet {
         val wallet =
             Wallet(

--- a/src/main/kotlin/it/pagopa/wallet/domain/services/ServiceStatus.kt
+++ b/src/main/kotlin/it/pagopa/wallet/domain/services/ServiceStatus.kt
@@ -3,5 +3,29 @@ package it.pagopa.wallet.domain.services
 enum class ServiceStatus {
     ENABLED,
     INCOMING,
-    DISABLED
+    DISABLED;
+
+    companion object {
+        fun canChangeToStatus(requested: ServiceStatus, global: ServiceStatus): Boolean {
+            /*
+                Truth table (E=ENABLED, D=DISABLED, I=INCOMING)
+
+                       Requested
+                        E  D  I
+                 G     ┌──┬──┬──┐
+                 l   E │OK│OK│NO│
+                 o     ├──┼──┼──┤
+                 b   D │NO│OK│NO│
+                 a     ├──┼──┼──┤
+                 l   I │NO│OK│OK│
+                       └──┴──┴──┘
+            */
+
+            return when (requested) {
+                ENABLED -> global == ENABLED
+                INCOMING -> global == INCOMING
+                DISABLED -> true
+            }
+        }
+    }
 }

--- a/src/main/kotlin/it/pagopa/wallet/exception/WalletServiceStatusConflictException.kt
+++ b/src/main/kotlin/it/pagopa/wallet/exception/WalletServiceStatusConflictException.kt
@@ -1,0 +1,12 @@
+package it.pagopa.wallet.exception
+
+import it.pagopa.wallet.domain.services.ServiceName
+import it.pagopa.wallet.domain.services.ServiceStatus
+
+class WalletServiceStatusConflictException(
+    val updatedServices: Map<ServiceName, ServiceStatus>,
+    val failedServices: Map<ServiceName, ServiceStatus>
+) :
+    RuntimeException(
+        "Wallet services update failed, could not update services ${failedServices.keys}"
+    )

--- a/src/main/kotlin/it/pagopa/wallet/services/WalletServiceUpdateData.kt
+++ b/src/main/kotlin/it/pagopa/wallet/services/WalletServiceUpdateData.kt
@@ -1,0 +1,11 @@
+package it.pagopa.wallet.services
+
+import it.pagopa.wallet.documents.wallets.Wallet
+import it.pagopa.wallet.domain.services.ServiceName
+import it.pagopa.wallet.domain.services.ServiceStatus
+
+data class WalletServiceUpdateData(
+    val successfullyUpdatedServices: Map<ServiceName, ServiceStatus>,
+    val servicesWithUpdateFailed: Map<ServiceName, ServiceStatus>,
+    val updatedWallet: Wallet
+)

--- a/src/test/kotlin/it/pagopa/wallet/WalletTestUtils.kt
+++ b/src/test/kotlin/it/pagopa/wallet/WalletTestUtils.kt
@@ -511,13 +511,14 @@ object WalletTestUtils {
             .useDiagnosticTracing(false)
             .paymentMethodId(PAYMENT_METHOD_ID_CARDS.value)
 
-    val PATCH_SERVICE_1: PatchServiceDto =
-        PatchServiceDto().name(ServiceNameDto.PAGOPA).status(ServicePatchStatusDto.DISABLED)
+    val WALLET_SERVICE_1: WalletServiceDto =
+        WalletServiceDto().name(ServiceNameDto.PAGOPA).status(WalletServiceStatusDto.DISABLED)
 
-    val PATCH_SERVICE_2: PatchServiceDto =
-        PatchServiceDto().name(ServiceNameDto.PAGOPA).status(ServicePatchStatusDto.ENABLED)
+    val WALLET_SERVICE_2: WalletServiceDto =
+        WalletServiceDto().name(ServiceNameDto.PAGOPA).status(WalletServiceStatusDto.ENABLED)
 
-    val FLUX_PATCH_SERVICES: List<PatchServiceDto> = listOf(PATCH_SERVICE_1, PATCH_SERVICE_2)
+    val UPDATE_SERVICES_BODY: WalletServiceUpdateRequestDto =
+        WalletServiceUpdateRequestDto().services(listOf(WALLET_SERVICE_1, WALLET_SERVICE_2))
 
     fun getValidCardsPaymentMethod(): PaymentMethodResponse {
         return PaymentMethodResponse()

--- a/src/test/kotlin/it/pagopa/wallet/domain/services/ServiceStatusTest.kt
+++ b/src/test/kotlin/it/pagopa/wallet/domain/services/ServiceStatusTest.kt
@@ -1,0 +1,33 @@
+package it.pagopa.wallet.domain.services
+
+import java.util.stream.Stream
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+class ServiceStatusTest {
+    companion object {
+        @JvmStatic
+        private fun statusChangeResult() =
+            Stream.of(
+                Arguments.of(Triple(ServiceStatus.INCOMING, ServiceStatus.INCOMING, true)),
+                Arguments.of(Triple(ServiceStatus.INCOMING, ServiceStatus.DISABLED, false)),
+                Arguments.of(Triple(ServiceStatus.INCOMING, ServiceStatus.ENABLED, false)),
+                Arguments.of(Triple(ServiceStatus.DISABLED, ServiceStatus.INCOMING, true)),
+                Arguments.of(Triple(ServiceStatus.DISABLED, ServiceStatus.DISABLED, true)),
+                Arguments.of(Triple(ServiceStatus.DISABLED, ServiceStatus.ENABLED, true)),
+                Arguments.of(Triple(ServiceStatus.ENABLED, ServiceStatus.INCOMING, false)),
+                Arguments.of(Triple(ServiceStatus.ENABLED, ServiceStatus.DISABLED, false)),
+                Arguments.of(Triple(ServiceStatus.ENABLED, ServiceStatus.ENABLED, true)),
+            )
+    }
+
+    @ParameterizedTest
+    @MethodSource("statusChangeResult")
+    fun checkCanChangeStatus(args: Triple<ServiceStatus, ServiceStatus, Boolean>) {
+        val (requested, global, expected) = args
+
+        assertEquals(expected, ServiceStatus.canChangeToStatus(requested, global))
+    }
+}

--- a/src/test/kotlin/it/pagopa/wallet/services/WalletServiceTest.kt
+++ b/src/test/kotlin/it/pagopa/wallet/services/WalletServiceTest.kt
@@ -9,6 +9,8 @@ import it.pagopa.wallet.WalletTestUtils.NOTIFY_WALLET_REQUEST_OK_OPERATION_RESUL
 import it.pagopa.wallet.WalletTestUtils.ORDER_ID
 import it.pagopa.wallet.WalletTestUtils.PAYMENT_METHOD_ID_APM
 import it.pagopa.wallet.WalletTestUtils.PAYMENT_METHOD_ID_CARDS
+import it.pagopa.wallet.WalletTestUtils.SERVICE_DOCUMENT
+import it.pagopa.wallet.WalletTestUtils.SERVICE_ID
 import it.pagopa.wallet.WalletTestUtils.SERVICE_NAME
 import it.pagopa.wallet.WalletTestUtils.USER_ID
 import it.pagopa.wallet.WalletTestUtils.WALLET_UUID
@@ -32,14 +34,20 @@ import it.pagopa.wallet.client.EcommercePaymentMethodsClient
 import it.pagopa.wallet.client.NpgClient
 import it.pagopa.wallet.config.OnboardingReturnUrlConfig
 import it.pagopa.wallet.config.SessionUrlConfig
+import it.pagopa.wallet.documents.service.Service as ServiceDocument
 import it.pagopa.wallet.documents.wallets.Wallet
 import it.pagopa.wallet.documents.wallets.details.CardDetails
+import it.pagopa.wallet.domain.services.Service
+import it.pagopa.wallet.domain.services.ServiceId
+import it.pagopa.wallet.domain.services.ServiceName
 import it.pagopa.wallet.domain.services.ServiceStatus
+import it.pagopa.wallet.domain.wallets.Application
 import it.pagopa.wallet.domain.wallets.ContractId
 import it.pagopa.wallet.domain.wallets.WalletId
 import it.pagopa.wallet.exception.*
 import it.pagopa.wallet.repositories.NpgSession
 import it.pagopa.wallet.repositories.NpgSessionsTemplateWrapper
+import it.pagopa.wallet.repositories.ServiceRepository
 import it.pagopa.wallet.repositories.WalletRepository
 import it.pagopa.wallet.util.UniqueIdUtils
 import java.net.URI
@@ -65,6 +73,7 @@ import reactor.test.StepVerifier
 
 class WalletServiceTest {
     private val walletRepository: WalletRepository = mock()
+    private val serviceRepository: ServiceRepository = mock()
     private val ecommercePaymentMethodsClient: EcommercePaymentMethodsClient = mock()
     private val npgClient: NpgClient = mock()
     private val npgSessionRedisTemplate: NpgSessionsTemplateWrapper = mock()
@@ -96,6 +105,7 @@ class WalletServiceTest {
     private val walletService: WalletService =
         WalletService(
             walletRepository,
+            serviceRepository,
             ecommercePaymentMethodsClient,
             npgClient,
             npgSessionRedisTemplate,
@@ -1003,7 +1013,7 @@ class WalletServiceTest {
     }
 
     @Test
-    fun `should patch wallet document when adding services`() {
+    fun `should patch wallet document when adding services with valid statuses`() {
         /* preconditions */
 
         mockStatic(UUID::class.java, Mockito.CALLS_REAL_METHODS).use {
@@ -1018,8 +1028,30 @@ class WalletServiceTest {
                 val walletDocumentEmptyServicesNullDetailsNoPaymentInstrument =
                     walletDocumentEmptyServicesNullDetailsNoPaymentInstrument()
 
+                val newServiceStatus = ServiceStatus.ENABLED
                 val expectedLoggedAction =
-                    LoggedAction(wallet, WalletPatchEvent(WALLET_UUID.value.toString()))
+                    LoggedAction(
+                        WalletServiceUpdateData(
+                            updatedWallet =
+                                wallet
+                                    .copy(
+                                        applications =
+                                            listOf(
+                                                Application(
+                                                    SERVICE_ID,
+                                                    SERVICE_NAME,
+                                                    newServiceStatus,
+                                                    mockedInstant
+                                                )
+                                            ),
+                                        updateDate = mockedInstant
+                                    )
+                                    .toDocument(),
+                            successfullyUpdatedServices = mapOf(SERVICE_NAME to newServiceStatus),
+                            servicesWithUpdateFailed = mapOf()
+                        ),
+                        WalletPatchEvent(WALLET_UUID.value.toString())
+                    )
 
                 val walletArgumentCaptor: KArgumentCaptor<Wallet> = argumentCaptor<Wallet>()
 
@@ -1031,13 +1063,18 @@ class WalletServiceTest {
                 given { walletRepository.save(walletArgumentCaptor.capture()) }
                     .willAnswer { Mono.just(it.arguments[0]) }
 
+                given { serviceRepository.findById(SERVICE_NAME.name) }
+                    .willReturn(
+                        Mono.just(SERVICE_DOCUMENT.copy(status = ServiceStatus.ENABLED.name))
+                    )
+
                 /* test */
                 assertTrue(wallet.applications.isEmpty())
 
                 StepVerifier.create(
-                        walletService.patchWallet(
+                        walletService.updateWalletServices(
                             WALLET_UUID.value,
-                            Pair(SERVICE_NAME, ServiceStatus.ENABLED)
+                            listOf(Pair(SERVICE_NAME, newServiceStatus))
                         )
                     )
                     .expectNext(expectedLoggedAction)
@@ -1050,7 +1087,7 @@ class WalletServiceTest {
     }
 
     @Test
-    fun `should patch wallet document editing service status`() {
+    fun `should patch wallet document editing service status with valid status`() {
         /* preconditions */
 
         mockStatic(UUID::class.java, Mockito.CALLS_REAL_METHODS).use {
@@ -1059,8 +1096,32 @@ class WalletServiceTest {
             mockStatic(Instant::class.java, Mockito.CALLS_REAL_METHODS).use {
                 it.`when`<Instant> { Instant.now() }.thenReturn(mockedInstant)
 
+                val newServiceStatus = ServiceStatus.ENABLED
+
                 val expectedLoggedAction =
-                    LoggedAction(walletDomain(), WalletPatchEvent(WALLET_UUID.value.toString()))
+                    LoggedAction(
+                        WalletServiceUpdateData(
+                            updatedWallet =
+                                walletDomain()
+                                    .copy(
+                                        applications =
+                                            listOf(
+                                                Application(
+                                                    SERVICE_ID,
+                                                    SERVICE_NAME,
+                                                    newServiceStatus,
+                                                    mockedInstant
+                                                )
+                                            ),
+                                        updateDate = mockedInstant
+                                    )
+                                    .toDocument(),
+                            successfullyUpdatedServices =
+                                mapOf(SERVICE_NAME to ServiceStatus.ENABLED),
+                            servicesWithUpdateFailed = mapOf()
+                        ),
+                        WalletPatchEvent(WALLET_UUID.value.toString())
+                    )
 
                 val walletArgumentCaptor: KArgumentCaptor<Wallet> = argumentCaptor<Wallet>()
                 val walletDocument = walletDocument()
@@ -1069,6 +1130,11 @@ class WalletServiceTest {
 
                 given { walletRepository.save(walletArgumentCaptor.capture()) }
                     .willReturn(Mono.just(walletDocument))
+
+                given { serviceRepository.findById(SERVICE_NAME.name) }
+                    .willReturn(
+                        Mono.just(SERVICE_DOCUMENT.copy(status = ServiceStatus.ENABLED.name))
+                    )
 
                 /* test */
                 assertEquals(walletDocument.applications.size, 1)
@@ -1079,9 +1145,104 @@ class WalletServiceTest {
                 )
 
                 StepVerifier.create(
-                        walletService.patchWallet(
+                        walletService.updateWalletServices(
                             WALLET_UUID.value,
-                            Pair(SERVICE_NAME, ServiceStatus.ENABLED)
+                            listOf(Pair(SERVICE_NAME, newServiceStatus))
+                        )
+                    )
+                    .expectNext(expectedLoggedAction)
+                    .verifyComplete()
+
+                val walletDocumentToSave = walletArgumentCaptor.firstValue
+                assertEquals(walletDocumentToSave.applications.size, 1)
+                assertEquals(walletDocumentToSave.applications[0].name, SERVICE_NAME.name)
+                assertEquals(
+                    walletDocumentToSave.applications[0].status,
+                    ServiceStatus.ENABLED.toString()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `should patch wallet document editing service status and return services that could not be changed`() {
+        /* preconditions */
+
+        mockStatic(UUID::class.java, Mockito.CALLS_REAL_METHODS).use {
+            it.`when`<UUID> { UUID.randomUUID() }.thenReturn(mockedUUID)
+
+            mockStatic(Instant::class.java, Mockito.CALLS_REAL_METHODS).use {
+                it.`when`<Instant> { Instant.now() }.thenReturn(mockedInstant)
+
+                val newServiceStatus = ServiceStatus.ENABLED
+
+                val disabledService =
+                    Service(
+                        ServiceId(UUID.randomUUID()),
+                        ServiceName("INCOMING_SERVICE"),
+                        ServiceStatus.INCOMING,
+                        Instant.now()
+                    )
+
+                val walletDocument = walletDocument()
+
+                val expectedLoggedAction =
+                    LoggedAction(
+                        WalletServiceUpdateData(
+                            updatedWallet =
+                                walletDomain()
+                                    .copy(
+                                        applications =
+                                            listOf(
+                                                Application(
+                                                    SERVICE_ID,
+                                                    SERVICE_NAME,
+                                                    newServiceStatus,
+                                                    mockedInstant
+                                                )
+                                            ),
+                                        updateDate = mockedInstant
+                                    )
+                                    .toDocument(),
+                            successfullyUpdatedServices =
+                                mapOf(SERVICE_NAME to ServiceStatus.ENABLED),
+                            servicesWithUpdateFailed =
+                                mapOf(disabledService.name to ServiceStatus.INCOMING)
+                        ),
+                        WalletPatchEvent(WALLET_UUID.value.toString())
+                    )
+
+                val walletArgumentCaptor: KArgumentCaptor<Wallet> = argumentCaptor<Wallet>()
+
+                given { walletRepository.findById(any<String>()) }
+                    .willReturn(Mono.just(walletDocument))
+
+                given { walletRepository.save(walletArgumentCaptor.capture()) }
+                    .willReturn(Mono.just(walletDocument))
+
+                given { serviceRepository.findById(SERVICE_NAME.name) }
+                    .willReturn(
+                        Mono.just(SERVICE_DOCUMENT.copy(status = ServiceStatus.ENABLED.name))
+                    )
+
+                given { serviceRepository.findById(disabledService.name.name) }
+                    .willReturn(Mono.just(ServiceDocument.fromDomain(disabledService)))
+
+                /* test */
+                assertEquals(walletDocument.applications.size, 1)
+                assertEquals(walletDocument.applications[0].name, SERVICE_NAME.name)
+                assertEquals(
+                    walletDocument.applications[0].status,
+                    ServiceStatus.DISABLED.toString()
+                )
+
+                StepVerifier.create(
+                        walletService.updateWalletServices(
+                            WALLET_UUID.value,
+                            listOf(
+                                Pair(SERVICE_NAME, newServiceStatus),
+                                Pair(disabledService.name, newServiceStatus)
+                            )
                         )
                     )
                     .expectNext(expectedLoggedAction)
@@ -1106,9 +1267,9 @@ class WalletServiceTest {
         /* test */
 
         StepVerifier.create(
-                walletService.patchWallet(
+                walletService.updateWalletServices(
                     WALLET_UUID.value,
-                    Pair(SERVICE_NAME, ServiceStatus.ENABLED)
+                    listOf(Pair(SERVICE_NAME, ServiceStatus.ENABLED))
                 )
             )
             .expectError(WalletNotFoundException::class.java)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
 * refactor: move `PATCH /wallet/{id}` -> `PUT /wallet/{id}/services`
 * In case of partial wallet services update, return a `409 Conflict` with both the services that were updated and the services that generated the conflict

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

For the HTTP method change: requested by our users :)
For the status code: it can give more information to downstream users on what to do in case of not being able to update wallet services as desired

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Unit tests

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
