### PR TITLE
[CHK-2258] feat(auth-data): add support for returning wallet auth data for APMs

### DIFF
--- a/api-spec/wallet-api.yaml
+++ b/api-spec/wallet-api.yaml
@@ -1077,12 +1077,42 @@ components:
         contractId:
           description: Payment method identifier
           type: string
-        bin:
-          type: string
-          description: Bin of user card
         brand:
           description: The card brand name
           type: string
+        paymentMethodData:
+          oneOf:
+            - $ref: "#/components/schemas/WalletAuthCardData"
+            - $ref: "#/components/schemas/WalletAuthAPMData"
+          discriminator:
+            propertyName: paymentMethodType
+            mapping:
+              cards: "#/components/schemas/WalletAuthCardData"
+              apm: "#/components/schemas/WalletAuthAPMData"
+      required:
+        - contractId
+        - brand
+        - paymentMethodData
+    WalletAuthCardData:
+      x-discriminator-value: cards
+      type: object
+      properties:
+        paymentMethodType:
+          type: string
+        bin:
+          type: string
+          description: Bin of user card
+      required:
+        - paymentMethodType
+        - bin
+    WalletAuthAPMData:
+      x-discriminator-value: apm
+      type: object
+      properties:
+        paymentMethodType:
+          type: string
+      required:
+        - paymentMethodType
   securitySchemes:
     bearerAuth:
       type: http

--- a/src/test/kotlin/it/pagopa/wallet/WalletTestUtils.kt
+++ b/src/test/kotlin/it/pagopa/wallet/WalletTestUtils.kt
@@ -488,12 +488,19 @@ object WalletTestUtils {
                     .holder(HOLDER_NAME.holderName)
             )
 
-    fun walletAuthDataDto() =
+    fun walletCardAuthDataDto() =
         WalletAuthDataDto()
             .walletId(WALLET_UUID.value)
             .contractId(CONTRACT_ID.contractId)
-            .bin(BIN.bin)
             .brand(BRAND.value)
+            .paymentMethodData(WalletAuthCardDataDto().bin(BIN.bin).paymentMethodType("cards"))
+
+    fun walletAPMAuthDataDto() =
+        WalletAuthDataDto()
+            .walletId(WALLET_UUID.value)
+            .contractId(CONTRACT_ID.contractId)
+            .brand("PAYPAL")
+            .paymentMethodData(WalletAuthAPMDataDto().paymentMethodType("apm"))
 
     val SERVICE_DOCUMENT: Service =
         Service(

--- a/src/test/kotlin/it/pagopa/wallet/controllers/WalletControllerTest.kt
+++ b/src/test/kotlin/it/pagopa/wallet/controllers/WalletControllerTest.kt
@@ -309,10 +309,28 @@ class WalletControllerTest {
     }
 
     @Test
-    fun testGetWalletAuthDataSuccess() = runTest {
+    fun testGetWalletCardAuthDataSuccess() = runTest {
         /* preconditions */
         val walletId = WalletId(UUID.randomUUID())
-        val walletAuthData = WalletTestUtils.walletAuthDataDto()
+        val walletAuthData = WalletTestUtils.walletCardAuthDataDto()
+        val jsonToTest = objectMapper.writeValueAsString(walletAuthData)
+        given { walletService.findWalletAuthData(walletId) }.willReturn(mono { walletAuthData })
+        /* test */
+        webClient
+            .get()
+            .uri("/wallets/{walletId}/auth-data", mapOf("walletId" to walletId.value.toString()))
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .json(jsonToTest)
+    }
+
+    @Test
+    fun testGetWalletAPMAuthDataSuccess() = runTest {
+        /* preconditions */
+        val walletId = WalletId(UUID.randomUUID())
+        val walletAuthData = WalletTestUtils.walletAPMAuthDataDto()
         val jsonToTest = objectMapper.writeValueAsString(walletAuthData)
         given { walletService.findWalletAuthData(walletId) }.willReturn(mono { walletAuthData })
         /* test */


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
 * add support for returning wallet auth data for APM wallets

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change allows the `GET /wallet/{walletId}/auth-data` endpoint to return valid data for APM wallets. This endpoint is used when paying with a wallet to get data about the wallet that is necessary for authorization/receipt purposes only (for all methods: the brand icon, for cards: the bin in order to check fees validity).

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
