### PR TITLE
fix: added null clientId into payment method client

### DIFF
--- a/src/main/kotlin/it/pagopa/wallet/client/EcommercePaymentMethodsClient.kt
+++ b/src/main/kotlin/it/pagopa/wallet/client/EcommercePaymentMethodsClient.kt
@@ -27,7 +27,7 @@ class EcommercePaymentMethodsClient(
         val maybePaymentMethodResponse: Mono<PaymentMethodResponse> =
             try {
                 logger.info("Starting getPaymentMethod given id $paymentMethodId")
-                ecommercePaymentMethodsClient.getPaymentMethod(paymentMethodId)
+                ecommercePaymentMethodsClient.getPaymentMethod(paymentMethodId, null)
             } catch (e: WebClientResponseException) {
                 Mono.error(e)
             }

--- a/src/test/kotlin/it/pagopa/wallet/client/EcommercePaymentMethodClientTest.kt
+++ b/src/test/kotlin/it/pagopa/wallet/client/EcommercePaymentMethodClientTest.kt
@@ -24,7 +24,7 @@ class EcommercePaymentMethodClientTest {
         val paymentMethod = WalletTestUtils.getValidCardsPaymentMethod()
 
         // prerequisite
-        given(paymentMethodsApi.getPaymentMethod(paymentMethodId))
+        given(paymentMethodsApi.getPaymentMethod(paymentMethodId, null))
             .willReturn(mono { paymentMethod })
 
         // test and assertions
@@ -37,7 +37,7 @@ class EcommercePaymentMethodClientTest {
     fun `Should map payment method service error response to EcommercePaymentMethodsClientException with BAD_GATEWAY error for exception during communication`() {
         val paymentMethodId = WalletTestUtils.PAYMENT_METHOD_ID_CARDS.toString()
         // prerequisite
-        given(paymentMethodsApi.getPaymentMethod(paymentMethodId))
+        given(paymentMethodsApi.getPaymentMethod(paymentMethodId, null))
             .willThrow(
                 WebClientResponseException.create(
                     500,
@@ -60,7 +60,7 @@ class EcommercePaymentMethodClientTest {
     fun `Should map payment method service error response to EcommercePaymentMethodsClientException with INTERNAL_SERVER_ERROR error for 401 from ecommerce-payment-methods`() {
         val paymentMethodId = WalletTestUtils.PAYMENT_METHOD_ID_CARDS.toString()
         // prerequisite
-        given(paymentMethodsApi.getPaymentMethod(paymentMethodId))
+        given(paymentMethodsApi.getPaymentMethod(paymentMethodId, null))
             .willThrow(
                 WebClientResponseException.create(
                     401,
@@ -83,7 +83,7 @@ class EcommercePaymentMethodClientTest {
     fun `Should map payment method service error response to EcommercePaymentMethodsClientException with BAD_GATEWAY error for 500 from ecommerce-payment-methods`() {
         val paymentMethodId = WalletTestUtils.PAYMENT_METHOD_ID_CARDS.toString()
         // prerequisite
-        given(paymentMethodsApi.getPaymentMethod(paymentMethodId))
+        given(paymentMethodsApi.getPaymentMethod(paymentMethodId, null))
             .willThrow(
                 WebClientResponseException.create(
                     500,
@@ -106,7 +106,7 @@ class EcommercePaymentMethodClientTest {
     fun `Should map payment method service error response to EcommercePaymentMethodsClientException with BAD_GATEWAY error for 404 from ecommerce-payment-methods`() {
         val paymentMethodId = WalletTestUtils.PAYMENT_METHOD_ID_CARDS.toString()
         // prerequisite
-        given(paymentMethodsApi.getPaymentMethod(paymentMethodId))
+        given(paymentMethodsApi.getPaymentMethod(paymentMethodId, null))
             .willThrow(
                 WebClientResponseException.create(
                     404,
@@ -129,7 +129,7 @@ class EcommercePaymentMethodClientTest {
     fun `Should map payment method service error response to EcommercePaymentMethodsClientException with BAD_GATEWAY error for 400 from ecommerce-payment-methods`() {
         val paymentMethodId = WalletTestUtils.PAYMENT_METHOD_ID_CARDS.toString()
         // prerequisite
-        given(paymentMethodsApi.getPaymentMethod(paymentMethodId))
+        given(paymentMethodsApi.getPaymentMethod(paymentMethodId, null))
             .willThrow(
                 WebClientResponseException.create(
                     400,
@@ -154,7 +154,7 @@ class EcommercePaymentMethodClientTest {
         val paymentMethod = WalletTestUtils.getDisabledCardsPaymentMethod()
 
         // prerequisite
-        given(paymentMethodsApi.getPaymentMethod(paymentMethodId))
+        given(paymentMethodsApi.getPaymentMethod(paymentMethodId, null))
             .willReturn(mono { paymentMethod })
 
         // test and assertions
@@ -172,7 +172,7 @@ class EcommercePaymentMethodClientTest {
         val paymentMethod = WalletTestUtils.getInvalidCardsPaymentMethod()
 
         // prerequisite
-        given(paymentMethodsApi.getPaymentMethod(paymentMethodId))
+        given(paymentMethodsApi.getPaymentMethod(paymentMethodId, null))
             .willReturn(mono { paymentMethod })
 
         // test and assertions


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
After the change to openapi to add the optional clientID in the GET of the payment method, this fix on the wallet was deemed necessary.
We pass the parameter to null since the secret associated with the request request will be part of a group that will statically insert the x-client-id IO in the request header. https://github.com/pagopa/pagopa-infra/blob/5a6f60eb5de1866eddeff4c3a07c392dbd504ef4/src/domains/ecommerce-app/api/ecommerce-payment-methods-service/v1/_base_policy.xml.tpl#L16
<!--- Describe your changes in detail -->

#### Motivation and Context
The change was made to have the code filled in.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
