### PR TITLE
[CHK-2722] Filter get wallets by userId filtering by VALIDATED status

### DIFF
--- a/api-spec/wallet-api.yaml
+++ b/api-spec/wallet-api.yaml
@@ -918,7 +918,6 @@ components:
       required:
         - type
         - pspId
-        - maskedEmail
     WalletApplicationUpdateRequest:
       type: object
       description: Wallet update request

--- a/api-tests/wallet_local_cards.collection.tests.json
+++ b/api-tests/wallet_local_cards.collection.tests.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "de2c1345-7029-410e-b808-df6e8984b243",
+		"_postman_id": "4c242096-f9f3-44b4-ac33-c682f5bfebad",
 		"name": "Wallet CARDS onboarding",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "23963988"
+		"_exporter_id": "23305473"
 	},
 	"item": [
 		{
@@ -370,7 +370,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n  \"applications\": [\n    \"PAGOA\"\n  ],\n  \"useDiagnosticTracing\": {{USE_DIAGNOSTIC_TRACING}},\n  \"paymentMethodId\": \"{{PAYMENT_METHOD_ID}}\"\n}",
+					"raw": "{\n  \"applications\": [\n    \"PAGOPA\"\n  ],\n  \"useDiagnosticTracing\": {{USE_DIAGNOSTIC_TRACING}},\n  \"paymentMethodId\": \"{{PAYMENT_METHOD_ID}}\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -462,94 +462,6 @@
 					"path": [
 						"wallets",
 						"{{INVALID_WALLET_ID}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Get wallet by x-user-id",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"[Wallet for onboarding CARDS] Get wallet by x-user-id return wallet information GET /wallets/\", function () {",
-							"    pm.response.to.have.status(200);",
-							"    const response = pm.response.json();",
-							"    pm.expect(response.wallets).to.be.not.null;",
-							"    const createdWallet = response.wallets[0];",
-							"    pm.expect(createdWallet.walletId).to.be.a(\"string\")",
-							"    pm.expect(createdWallet.userId).to.be.a(\"string\")",
-							"    pm.expect(createdWallet.paymentMethodId).to.be.a(\"string\")",
-							"    pm.expect(createdWallet.status).to.be.a(\"string\")",
-							"    pm.expect(createdWallet.status).to.be.eq(\"CREATED\")",
-							"    pm.expect(createdWallet.walletId).to.be.eq(pm.environment.get(\"WALLET_ID\"))",
-							"    pm.expect(createdWallet.userId).to.be.eq(pm.environment.get(\"x-user-id\"))",
-							"    pm.expect(createdWallet.paymentMethodId).to.be.eq(pm.environment.get(\"PAYMENT_METHOD_ID\"))",
-							"});",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "x-user-id",
-						"value": "{{x-user-id}}",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{HOSTNAME}}/wallets",
-					"host": [
-						"{{HOSTNAME}}"
-					],
-					"path": [
-						"wallets"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Get wallet invalid x-user-id",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"[Wallet for onboarding CARDS] Get wallet by x-user-id with error invalid format\", function () {",
-							"    pm.response.to.have.status(400);",
-							"    const detailErrorField = pm.response.json().detail;",
-							"    pm.expect(detailErrorField).to.be.contain(\"Input request is not valid\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "x-user-id",
-						"value": "{{invalid-x-user-id}}",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{HOSTNAME}}/wallets",
-					"host": [
-						"{{HOSTNAME}}"
-					],
-					"path": [
-						"wallets"
 					]
 				}
 			},
@@ -1131,6 +1043,95 @@
 						"sessions",
 						"{{INVALID_ORDER_ID}}",
 						"notifications"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get wallet by x-user-id",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"[Wallet for onboarding CARDS] Get wallet by x-user-id return wallet information GET /wallets/\", function () {",
+							"    pm.response.to.have.status(200);",
+							"    const response = pm.response.json();",
+							"    pm.expect(response.wallets).to.be.not.null;",
+							"    const createdWallet = response.wallets[0];",
+							"    pm.expect(createdWallet.walletId).to.be.a(\"string\")",
+							"    pm.expect(createdWallet.userId).to.be.a(\"string\")",
+							"    pm.expect(createdWallet.paymentMethodId).to.be.a(\"string\")",
+							"    pm.expect(createdWallet.status).to.be.a(\"string\")",
+							"    pm.expect(createdWallet.status).to.be.eq(\"VALIDATED\")",
+							"    pm.expect(createdWallet.walletId).to.be.eq(pm.environment.get(\"WALLET_ID\"))",
+							"    pm.expect(createdWallet.userId).to.be.eq(pm.environment.get(\"x-user-id\"))",
+							"    pm.expect(createdWallet.paymentMethodId).to.be.eq(pm.environment.get(\"PAYMENT_METHOD_ID\"))",
+							"});",
+							"",
+							""
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "x-user-id",
+						"value": "{{x-user-id}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{HOSTNAME}}/wallets",
+					"host": [
+						"{{HOSTNAME}}"
+					],
+					"path": [
+						"wallets"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get wallet invalid x-user-id",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"[Wallet for onboarding CARDS] Get wallet by x-user-id with error invalid format\", function () {",
+							"    pm.response.to.have.status(400);",
+							"    const detailErrorField = pm.response.json().detail;",
+							"    pm.expect(detailErrorField).to.be.contain(\"Input request is not valid\");",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "x-user-id",
+						"value": "{{invalid-x-user-id}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{HOSTNAME}}/wallets",
+					"host": [
+						"{{HOSTNAME}}"
+					],
+					"path": [
+						"wallets"
 					]
 				}
 			},

--- a/api-tests/wallet_local_paypal.collection.tests.json
+++ b/api-tests/wallet_local_paypal.collection.tests.json
@@ -635,6 +635,56 @@
 			"response": []
 		},
 		{
+			"name": "Get wallet by x-user-id",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"[Wallet for onboarding PAYPAL] Get wallet by x-user-id return wallet information GET /wallets/\", function () {",
+							"    pm.response.to.have.status(200);",
+							"    const response = pm.response.json();",
+							"    pm.expect(response.wallets).to.be.not.null;",
+							"    const createdWallet = response.wallets[0];",
+							"    pm.expect(createdWallet.walletId).to.be.a(\"string\")",
+							"    pm.expect(createdWallet.userId).to.be.a(\"string\")",
+							"    pm.expect(createdWallet.paymentMethodId).to.be.a(\"string\")",
+							"    pm.expect(createdWallet.status).to.be.a(\"string\")",
+							"    pm.expect(createdWallet.status).to.be.eq(\"VALIDATED\")",
+							"    pm.expect(createdWallet.walletId).to.be.eq(pm.environment.get(\"WALLET_ID\"))",
+							"    pm.expect(createdWallet.userId).to.be.eq(pm.environment.get(\"x-user-id\"))",
+							"    pm.expect(createdWallet.paymentMethodId).to.be.eq(pm.environment.get(\"PAYMENT_METHOD_ID\"))",
+							"});",
+							"",
+							""
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "x-user-id",
+						"value": "{{x-user-id}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{HOSTNAME}}/wallets",
+					"host": [
+						"{{HOSTNAME}}"
+					],
+					"path": [
+						"wallets"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Notify wallet invalid security token",
 			"event": [
 				{
@@ -982,56 +1032,6 @@
 						"sessions",
 						"{{ORDER_ID}}",
 						"notifications"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Get wallet by x-user-id",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"[Wallet for onboarding PAYPAL] Get wallet by x-user-id return wallet information GET /wallets/\", function () {",
-							"    pm.response.to.have.status(200);",
-							"    const response = pm.response.json();",
-							"    pm.expect(response.wallets).to.be.not.null;",
-							"    const createdWallet = response.wallets[0];",
-							"    pm.expect(createdWallet.walletId).to.be.a(\"string\")",
-							"    pm.expect(createdWallet.userId).to.be.a(\"string\")",
-							"    pm.expect(createdWallet.paymentMethodId).to.be.a(\"string\")",
-							"    pm.expect(createdWallet.status).to.be.a(\"string\")",
-							"    pm.expect(createdWallet.status).to.be.eq(\"VALIDATED\")",
-							"    pm.expect(createdWallet.walletId).to.be.eq(pm.environment.get(\"WALLET_ID\"))",
-							"    pm.expect(createdWallet.userId).to.be.eq(pm.environment.get(\"x-user-id\"))",
-							"    pm.expect(createdWallet.paymentMethodId).to.be.eq(pm.environment.get(\"PAYMENT_METHOD_ID\"))",
-							"});",
-							"",
-							""
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "x-user-id",
-						"value": "{{x-user-id}}",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{HOSTNAME}}/wallets",
-					"host": [
-						"{{HOSTNAME}}"
-					],
-					"path": [
-						"wallets"
 					]
 				}
 			},

--- a/api-tests/wallet_local_paypal.collection.tests.json
+++ b/api-tests/wallet_local_paypal.collection.tests.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "a47da677-6d8f-4cc2-b1c4-a325be4af8fd",
+		"_postman_id": "71b6db41-ced7-4027-a668-a9e23617d52d",
 		"name": "Wallet PAYPAL onboarding",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "23963988"
+		"_exporter_id": "23305473"
 	},
 	"item": [
 		{
@@ -455,94 +455,6 @@
 					"path": [
 						"wallets",
 						"{{INVALID_WALLET_ID}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Get wallet by x-user-id",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"[Wallet for onboarding PAYPAL] Get wallet by x-user-id return wallet information GET /wallets/\", function () {",
-							"    pm.response.to.have.status(200);",
-							"    const response = pm.response.json();",
-							"    pm.expect(response.wallets).to.be.not.null;",
-							"    const createdWallet = response.wallets[0];",
-							"    pm.expect(createdWallet.walletId).to.be.a(\"string\")",
-							"    pm.expect(createdWallet.userId).to.be.a(\"string\")",
-							"    pm.expect(createdWallet.paymentMethodId).to.be.a(\"string\")",
-							"    pm.expect(createdWallet.status).to.be.a(\"string\")",
-							"    pm.expect(createdWallet.status).to.be.eq(\"CREATED\")",
-							"    pm.expect(createdWallet.walletId).to.be.eq(pm.environment.get(\"WALLET_ID\"))",
-							"    pm.expect(createdWallet.userId).to.be.eq(pm.environment.get(\"x-user-id\"))",
-							"    pm.expect(createdWallet.paymentMethodId).to.be.eq(pm.environment.get(\"PAYMENT_METHOD_ID\"))",
-							"});",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "x-user-id",
-						"value": "{{x-user-id}}",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{HOSTNAME}}/wallets",
-					"host": [
-						"{{HOSTNAME}}"
-					],
-					"path": [
-						"wallets"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Get wallet invalid x-user-id",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"[Wallet for onboarding PAYPAL] Get wallet by x-user-id with error invalid format\", function () {",
-							"    pm.response.to.have.status(400);",
-							"    const detailErrorField = pm.response.json().detail;",
-							"    pm.expect(detailErrorField).to.be.contain(\"Input request is not valid\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "x-user-id",
-						"value": "{{invalid-x-user-id}}",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{HOSTNAME}}/wallets",
-					"host": [
-						"{{HOSTNAME}}"
-					],
-					"path": [
-						"wallets"
 					]
 				}
 			},
@@ -1070,6 +982,95 @@
 						"sessions",
 						"{{ORDER_ID}}",
 						"notifications"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get wallet by x-user-id",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"[Wallet for onboarding PAYPAL] Get wallet by x-user-id return wallet information GET /wallets/\", function () {",
+							"    pm.response.to.have.status(200);",
+							"    const response = pm.response.json();",
+							"    pm.expect(response.wallets).to.be.not.null;",
+							"    const createdWallet = response.wallets[0];",
+							"    pm.expect(createdWallet.walletId).to.be.a(\"string\")",
+							"    pm.expect(createdWallet.userId).to.be.a(\"string\")",
+							"    pm.expect(createdWallet.paymentMethodId).to.be.a(\"string\")",
+							"    pm.expect(createdWallet.status).to.be.a(\"string\")",
+							"    pm.expect(createdWallet.status).to.be.eq(\"VALIDATED\")",
+							"    pm.expect(createdWallet.walletId).to.be.eq(pm.environment.get(\"WALLET_ID\"))",
+							"    pm.expect(createdWallet.userId).to.be.eq(pm.environment.get(\"x-user-id\"))",
+							"    pm.expect(createdWallet.paymentMethodId).to.be.eq(pm.environment.get(\"PAYMENT_METHOD_ID\"))",
+							"});",
+							"",
+							""
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "x-user-id",
+						"value": "{{x-user-id}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{HOSTNAME}}/wallets",
+					"host": [
+						"{{HOSTNAME}}"
+					],
+					"path": [
+						"wallets"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get wallet invalid x-user-id",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"[Wallet for onboarding PAYPAL] Get wallet by x-user-id with error invalid format\", function () {",
+							"    pm.response.to.have.status(400);",
+							"    const detailErrorField = pm.response.json().detail;",
+							"    pm.expect(detailErrorField).to.be.contain(\"Input request is not valid\");",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "x-user-id",
+						"value": "{{invalid-x-user-id}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{HOSTNAME}}/wallets",
+					"host": [
+						"{{HOSTNAME}}"
+					],
+					"path": [
+						"wallets"
 					]
 				}
 			},

--- a/src/main/kotlin/it/pagopa/wallet/repositories/WalletRepository.kt
+++ b/src/main/kotlin/it/pagopa/wallet/repositories/WalletRepository.kt
@@ -13,6 +13,7 @@ interface WalletRepository : ReactiveCrudRepository<Wallet, String> {
 
     fun findByUserId(userId: String): Flux<Wallet>
     fun findByIdAndUserId(id: String, userId: String): Mono<Wallet>
+    fun findByUserIdAndStatus(userId: String, status: WalletStatusDto): Flux<Wallet>
 
     @Query(
         value = "{ 'userId' : ?0 , 'details.paymentInstrumentGatewayId' : ?1, 'status' : ?2 }",

--- a/src/main/kotlin/it/pagopa/wallet/services/WalletService.kt
+++ b/src/main/kotlin/it/pagopa/wallet/services/WalletService.kt
@@ -604,7 +604,10 @@ class WalletService(
     }
 
     fun findWalletByUserId(userId: UUID): Mono<WalletsDto> {
-        return walletRepository.findByUserId(userId.toString()).collectList().map { toWallets(it) }
+        return walletRepository
+            .findByUserIdAndStatus(userId.toString(), WalletStatusDto.VALIDATED)
+            .collectList()
+            .map { toWallets(it) }
     }
 
     fun findWalletAuthData(walletId: WalletId): Mono<WalletAuthDataDto> {

--- a/src/test/kotlin/it/pagopa/wallet/services/WalletServiceTest.kt
+++ b/src/test/kotlin/it/pagopa/wallet/services/WalletServiceTest.kt
@@ -2142,7 +2142,12 @@ class WalletServiceTest {
 
                 val walletsDto = WalletsDto().addWalletsItem(walletInfoDto)
 
-                given { walletRepository.findByUserId(USER_ID.id.toString()) }
+                given {
+                        walletRepository.findByUserIdAndStatus(
+                            USER_ID.id.toString(),
+                            WalletStatusDto.VALIDATED
+                        )
+                    }
                     .willAnswer { Flux.fromIterable(listOf(wallet)) }
                 given(walletUtils.getLogo(any())).willReturn(URI.create(logoUri))
                 /* test */


### PR DESCRIPTION
Add query for wallets filtering by status

#### List of Changes

Update GET wallets by userId. Now it returns only VALIDATED wallet for specific userId

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
