### PR TITLE
feat: make create session wallet idempotent

### DIFF
--- a/api-tests/wallet_local_cards.collection.tests.json
+++ b/api-tests/wallet_local_cards.collection.tests.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "bb99222d-8134-42dd-b6e3-6d8fa2b446a0",
+		"_postman_id": "6ce6d9d6-3af0-4d8c-97cd-dd525b67ce68",
 		"name": "Wallet CARDS onboarding",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "32950386"
+		"_exporter_id": "23963988"
 	},
 	"item": [
 		{
@@ -570,6 +570,96 @@
 			"response": []
 		},
 		{
+			"name": "Post sessions idempotent",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"const sdk = require('postman-collection');",
+							"",
+							"pm.test(\"[Wallet for onboarding CARDS] New wallet session re-created successfully with POST /wallets/:idWallet/sessions\", function () {",
+							"    pm.response.to.have.status(200);",
+							"",
+							"    const response = pm.response.json();",
+							"    const sessionData = response.sessionData;",
+							"    pm.expect(sessionData.paymentMethodType).to.be.eq(\"cards\");",
+							"    const cardFormFieldsDataWithoutSrc = sessionData.cardFormFields.map(form => {",
+							"        const { src, ...rest } = form;",
+							"        return rest;",
+							"    });",
+							"    const expectedCardFormFieldsDataWithoutSrc =",
+							"     [",
+							"            {",
+							"                \"type\": \"TEXT\",",
+							"                \"class\": \"CARD_FIELD\",",
+							"                \"id\": \"CARD_NUMBER\"",
+							"            },",
+							"            {",
+							"                \"type\": \"TEXT\",",
+							"                \"class\": \"CARD_FIELD\",",
+							"                \"id\": \"EXPIRATION_DATE\"",
+							"            },",
+							"            {",
+							"                \"type\": \"TEXT\",",
+							"                \"class\": \"CARD_FIELD\",",
+							"                \"id\": \"SECURITY_CODE\"",
+							"            },",
+							"            {",
+							"                \"type\": \"TEXT\",",
+							"                \"class\": \"CARD_FIELD\",",
+							"                \"id\": \"CARDHOLDER_NAME\"",
+							"            }",
+							"        ];",
+							"    pm.expect(expectedCardFormFieldsDataWithoutSrc).eql(cardFormFieldsDataWithoutSrc);",
+							"    pm.expect(response.orderId).to.be.a(\"string\");",
+							"    pm.environment.set(\"ORDER_ID\", response.orderId);",
+							" ",
+							"});",
+							"",
+							""
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {}
+			},
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "x-user-id",
+						"value": "{{x-user-id}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"paymentMethodType\": \"cards\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{HOSTNAME}}/wallets/{{WALLET_ID}}/sessions",
+					"host": [
+						"{{HOSTNAME}}"
+					],
+					"path": [
+						"wallets",
+						"{{WALLET_ID}}",
+						"sessions"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Post sessions Wallet not found",
 			"event": [
 				{
@@ -778,6 +868,70 @@
 						"sessions",
 						"{{ORDER_ID}}",
 						"validations"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Post sessions not allowed for wallet status different from CREATED or VALIDATION_REQUESTED",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"const sdk = require('postman-collection');",
+							"",
+							"pm.test(\"[Wallet for onboarding CARDS] Cannot create new wallet session with POST /wallets/:idWallet/sessions for wallet status != CREATED/VALIDATION_REQUESTED\", function () {",
+							"    pm.response.to.have.status(409);",
+							"    const walletId = pm.environment.get(\"WALLET_ID\");",
+							"    const responseBody = pm.response.json();",
+							"    const errorDetail = responseBody.detail;",
+							"    const errorTitle = responseBody.title;",
+							"    const errorStatus = responseBody.status;",
+							"    pm.expect(errorStatus).to.eq(409);",
+							"    pm.expect(errorTitle).to.eq(\"Conflict\");",
+							"    pm.expect(errorDetail).to.eq(`Conflict with walletId [${walletId}] with status [VALIDATION_REQUESTED]. Allowed statuses [CREATED, INITIALIZED]`);",
+							" ",
+							"});",
+							"",
+							""
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {}
+			},
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "x-user-id",
+						"value": "{{x-user-id}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"paymentMethodType\": \"cards\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{HOSTNAME}}/wallets/{{WALLET_ID}}/sessions",
+					"host": [
+						"{{HOSTNAME}}"
+					],
+					"path": [
+						"wallets",
+						"{{WALLET_ID}}",
+						"sessions"
 					]
 				}
 			},

--- a/api-tests/wallet_local_paypal.collection.tests.json
+++ b/api-tests/wallet_local_paypal.collection.tests.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "b37e0c99-bf3c-4a4e-b647-a6733e54f25f",
+		"_postman_id": "f8a26049-bdb8-4dc7-ae0c-a16e75dce3bb",
 		"name": "Wallet PAYPAL onboarding",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "32950386"
+		"_exporter_id": "23963988"
 	},
 	"item": [
 		{
@@ -537,6 +537,69 @@
 			"response": []
 		},
 		{
+			"name": "Post sessions Idempotent",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"const sdk = require('postman-collection');",
+							"",
+							"pm.test(\"[Wallet for onboarding PAYPAL] New wallet session re-created successfully with POST /wallets/:idWallet/sessions\", function () {",
+							"    pm.response.to.have.status(200);",
+							"",
+							"    const response = pm.response.json();",
+							"    const sessionData = response.sessionData;",
+							"    pm.expect(sessionData.paymentMethodType).to.be.eq(\"apm\");",
+							"    pm.expect(sessionData.redirectUrl).to.be.a(\"string\");",
+							"    pm.expect(response.orderId).to.be.a(\"string\");",
+							"    pm.environment.set(\"ORDER_ID\", response.orderId);",
+							"});",
+							"",
+							"",
+							""
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {}
+			},
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "x-user-id",
+						"value": "{{x-user-id}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"paymentMethodType\": \"paypal\",\n    \"pspId\": \"pspId\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{HOSTNAME}}/wallets/{{WALLET_ID}}/sessions",
+					"host": [
+						"{{HOSTNAME}}"
+					],
+					"path": [
+						"wallets",
+						"{{WALLET_ID}}",
+						"sessions"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Post sessions Wallet not found",
 			"event": [
 				{
@@ -643,6 +706,70 @@
 						"sessions",
 						"{{ORDER_ID}}",
 						"notifications"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Post sessions not allowed for wallet status different from CREATED or VALIDATION_REQUESTED",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"const sdk = require('postman-collection');",
+							"",
+							"pm.test(\"[Wallet for onboarding PAYPAL] Cannot create new wallet session with POST /wallets/:idWallet/sessions for wallet status != CREATED/VALIDATION_REQUESTED\", function () {",
+							"    pm.response.to.have.status(409);",
+							"    const walletId = pm.environment.get(\"WALLET_ID\");",
+							"    const responseBody = pm.response.json();",
+							"    const errorDetail = responseBody.detail;",
+							"    const errorTitle = responseBody.title;",
+							"    const errorStatus = responseBody.status;",
+							"    pm.expect(errorStatus).to.eq(409);",
+							"    pm.expect(errorTitle).to.eq(\"Conflict\");",
+							"    pm.expect(errorDetail).to.eq(`Conflict with walletId [${walletId}] with status [VALIDATED]. Allowed statuses [CREATED, VALIDATION_REQUESTED]`);",
+							" ",
+							"});",
+							"",
+							""
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {}
+			},
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "x-user-id",
+						"value": "{{x-user-id}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"paymentMethodType\": \"cards\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{HOSTNAME}}/wallets/{{WALLET_ID}}/sessions",
+					"host": [
+						"{{HOSTNAME}}"
+					],
+					"path": [
+						"wallets",
+						"{{WALLET_ID}}",
+						"sessions"
 					]
 				}
 			},

--- a/src/main/kotlin/it/pagopa/wallet/domain/wallets/Wallet.kt
+++ b/src/main/kotlin/it/pagopa/wallet/domain/wallets/Wallet.kt
@@ -108,12 +108,13 @@ data class Wallet(
     }
 
     fun expectInStatus(
-        vararg statuses: WalletStatusDto
+        vararg allowedStatuses: WalletStatusDto
     ): Either<WalletConflictStatusException, Wallet> {
-        return if (setOf(*statuses).contains(status)) {
+        val allowedStatusesSet = setOf(*allowedStatuses)
+        return if (allowedStatusesSet.contains(status)) {
             right(this)
         } else {
-            left(WalletConflictStatusException(id, status))
+            left(WalletConflictStatusException(id, status, allowedStatusesSet))
         }
     }
 
@@ -149,4 +150,20 @@ data class Wallet(
 
         return wallet
     }
+
+    /** Return input application iff it's present and enabled */
+    fun getApplication(walletApplicationId: WalletApplicationId): WalletApplication? =
+        applications.singleOrNull { application ->
+            application.id == walletApplicationId &&
+                application.status == WalletApplicationStatus.ENABLED
+        }
+
+    /**
+     * Return metadata for wallet application, iff application is present, enabled and metadata
+     * contains the searched key
+     */
+    fun getApplicationMetadata(
+        walletApplicationId: WalletApplicationId,
+        metadata: WalletApplicationMetadata.Metadata
+    ): String? = getApplication(walletApplicationId)?.metadata?.data?.get(metadata)
 }

--- a/src/main/kotlin/it/pagopa/wallet/exception/WalletConflictStatusException.kt
+++ b/src/main/kotlin/it/pagopa/wallet/exception/WalletConflictStatusException.kt
@@ -4,8 +4,14 @@ import it.pagopa.generated.wallet.model.WalletStatusDto
 import it.pagopa.wallet.domain.wallets.WalletId
 import org.springframework.http.HttpStatus
 
-class WalletConflictStatusException(val walletId: WalletId, walletStatusDto: WalletStatusDto) :
-    ApiError("Conflict with walletId [${walletId.value}] with status [${walletStatusDto.value}]") {
+class WalletConflictStatusException(
+    val walletId: WalletId,
+    walletStatusDto: WalletStatusDto,
+    allowedStatuses: Set<WalletStatusDto>
+) :
+    ApiError(
+        "Conflict with walletId [${walletId.value}] with status [${walletStatusDto.value}]. Allowed statuses $allowedStatuses"
+    ) {
     override fun toRestException(): RestApiException =
         RestApiException(HttpStatus.CONFLICT, "Conflict", message!!)
 }

--- a/src/main/kotlin/it/pagopa/wallet/services/WalletService.kt
+++ b/src/main/kotlin/it/pagopa/wallet/services/WalletService.kt
@@ -112,6 +112,7 @@ class WalletService(
             )
         val walletExpiryDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMM")
         val npgExpiryDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("MM/yy")
+        val pagopaWalletApplicationId = WalletApplicationId("PAGOPA")
     }
 
     /*
@@ -296,11 +297,41 @@ class WalletService(
             .findByIdAndUserId(walletId.value.toString(), xUserId.id.toString())
             .switchIfEmpty { Mono.error(WalletNotFoundException(walletId)) }
             .map { it.toDomain() }
-            .flatMap { it.expectInStatus(WalletStatusDto.CREATED).toMono() }
             .flatMap {
                 ecommercePaymentMethodsClient
                     .getPaymentMethodById(it.paymentMethodId.value.toString())
                     .map { paymentMethod -> paymentMethod to it }
+            }
+            .flatMap { (paymentMethod, wallet) ->
+                val isTransactionWithContextualOnboard =
+                    wallet
+                        .getApplicationMetadata(
+                            pagopaWalletApplicationId,
+                            WalletApplicationMetadata.Metadata.PAYMENT_WITH_CONTEXTUAL_ONBOARD
+                        )
+                        .toBoolean()
+                val isApm = paymentMethod.paymentTypeCode != "CP"
+                val allowedStatusesForRetryCreate =
+                    if (isTransactionWithContextualOnboard) {
+                        // allow for retry on createSessionWallet only for onboarding
+                        setOf(WalletStatusDto.CREATED)
+                    } else {
+                        if (isApm) {
+                            setOf(WalletStatusDto.CREATED, WalletStatusDto.VALIDATION_REQUESTED)
+                        } else {
+                            setOf(WalletStatusDto.CREATED, WalletStatusDto.INITIALIZED)
+                        }
+                    }
+                logger.info(
+                    "Wallet: [${walletId.value}], isApm: [$isApm], isTransactionWithContextualOnboard: [$isTransactionWithContextualOnboard] -> allowed statuses for retry create -> $allowedStatusesForRetryCreate"
+                )
+                Mono.just(paymentMethod)
+                    .zipWith(
+                        wallet
+                            .expectInStatus(*allowedStatusesForRetryCreate.toTypedArray())
+                            .toMono()
+                    )
+                    .map { Pair(it.t1, it.t2) }
             }
             .flatMap { (paymentMethodResponse, wallet) ->
                 generateNPGUniqueIdentifiers().map { (orderId, contractId) ->
@@ -308,21 +339,23 @@ class WalletService(
                 }
             }
             .flatMap { (uniqueIds, paymentMethod, wallet) ->
-                val pagopaApplication =
-                    wallet.applications.singleOrNull { application ->
-                        application.id == WalletApplicationId("PAGOPA") &&
-                            application.status == WalletApplicationStatus.ENABLED
-                    }
                 val isTransactionWithContextualOnboard =
-                    isWalletForTransactionWithContextualOnboard(pagopaApplication)
+                    wallet
+                        .getApplicationMetadata(
+                            pagopaWalletApplicationId,
+                            WalletApplicationMetadata.Metadata.PAYMENT_WITH_CONTEXTUAL_ONBOARD
+                        )
+                        .toBoolean()
                 val orderId = uniqueIds.first
                 val amount =
-                    if (isTransactionWithContextualOnboard)
-                        pagopaApplication
-                            ?.metadata
-                            ?.data
-                            ?.get(WalletApplicationMetadata.Metadata.AMOUNT)
-                    else null
+                    if (isTransactionWithContextualOnboard) {
+                        wallet.getApplicationMetadata(
+                            pagopaWalletApplicationId,
+                            WalletApplicationMetadata.Metadata.AMOUNT
+                        )
+                    } else {
+                        null
+                    }
                 val contractId = uniqueIds.second
                 val basePath = URI.create(sessionUrlConfig.basePath)
                 val merchantUrl = sessionUrlConfig.basePath
@@ -333,10 +366,10 @@ class WalletService(
                         isTransactionWithContextualOnboard,
                         wallet.id.value,
                         orderId,
-                        pagopaApplication
-                            ?.metadata
-                            ?.data
-                            ?.get(WalletApplicationMetadata.Metadata.TRANSACTION_ID)
+                        wallet.getApplicationMetadata(
+                            pagopaWalletApplicationId,
+                            WalletApplicationMetadata.Metadata.TRANSACTION_ID
+                        )
                     )
 
                 npgClient
@@ -350,8 +383,11 @@ class WalletService(
                                     Order()
                                         .orderId(orderId)
                                         .amount(
-                                            if (isTransactionWithContextualOnboard) amount
-                                            else CREATE_HOSTED_ORDER_REQUEST_VERIFY_AMOUNT
+                                            if (isTransactionWithContextualOnboard) {
+                                                amount
+                                            } else {
+                                                CREATE_HOSTED_ORDER_REQUEST_VERIFY_AMOUNT
+                                            }
                                         )
                                         .currency(CREATE_HOSTED_ORDER_REQUEST_CURRENCY_EUR)
                                     // TODO customerId must be valorised with the one coming from
@@ -359,8 +395,11 @@ class WalletService(
                                 .paymentSession(
                                     PaymentSession()
                                         .actionType(
-                                            if (isTransactionWithContextualOnboard) ActionType.PAY
-                                            else ActionType.VERIFY
+                                            if (isTransactionWithContextualOnboard) {
+                                                ActionType.PAY
+                                            } else {
+                                                ActionType.VERIFY
+                                            }
                                         )
                                         .recurrence(
                                             RecurringSettings()
@@ -369,8 +408,11 @@ class WalletService(
                                                 .contractType(RecurringContractType.CIT)
                                         )
                                         .amount(
-                                            if (isTransactionWithContextualOnboard) amount
-                                            else CREATE_HOSTED_ORDER_REQUEST_VERIFY_AMOUNT
+                                            if (isTransactionWithContextualOnboard) {
+                                                amount
+                                            } else {
+                                                CREATE_HOSTED_ORDER_REQUEST_VERIFY_AMOUNT
+                                            }
                                         )
                                         .language(CREATE_HOSTED_ORDER_REQUEST_LANGUAGE_ITA)
                                         .captureType(CaptureType.IMPLICIT)
@@ -1197,7 +1239,7 @@ class WalletService(
         }
 
     private fun isWalletForTransactionWithContextualOnboard(
-        application: it.pagopa.wallet.domain.wallets.WalletApplication?
+        application: WalletApplication?
     ): Boolean {
         if (application != null) {
             return application.metadata.data[

--- a/src/test/kotlin/it/pagopa/wallet/controllers/WalletControllerTest.kt
+++ b/src/test/kotlin/it/pagopa/wallet/controllers/WalletControllerTest.kt
@@ -958,7 +958,8 @@ class WalletControllerTest {
                 Mono.error(
                     WalletConflictStatusException(
                         WalletId.create(),
-                        WalletStatusDto.VALIDATION_REQUESTED
+                        WalletStatusDto.VALIDATION_REQUESTED,
+                        setOf()
                     )
                 )
             )

--- a/src/test/kotlin/it/pagopa/wallet/services/WalletServiceTest.kt
+++ b/src/test/kotlin/it/pagopa/wallet/services/WalletServiceTest.kt
@@ -87,6 +87,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mockito
 import org.mockito.Mockito.anyString
@@ -118,7 +119,7 @@ class WalletServiceTest {
             "http://localhost:1234",
             "/esito",
             "/annulla",
-            "http://localhost/payment-wallet-notifications/v1/wallets/{walletId}/sessions/{orderId}",
+            "http://localhost/payment-wallet-notifications/v1/wallets/{walletId}/sessions/{orderId}?sessionToken={sessionToken}",
             "http://localhost/payment-wallet-notifications/v1/transaction/{transactionId}/wallets/{walletId}/sessions/{orderId}/notifications?sessionToken={sessionToken}"
         )
 
@@ -802,16 +803,19 @@ class WalletServiceTest {
             val merchantUrl = sessionUrlConfig.basePath
             val resultUrl = basePath.resolve(sessionUrlConfig.outcomeSuffix)
             val cancelUrl = basePath.resolve(sessionUrlConfig.cancelSuffix)
+            val sessionToken = "sessionToken"
             val notificationUrl =
                 UriComponentsBuilder.fromHttpUrl(sessionUrlConfig.notificationUrl)
                     .build(
                         mapOf(
                             Pair("walletId", walletDocumentCreatedStatus.id),
                             Pair("orderId", orderId),
+                            Pair("sessionToken", sessionToken)
                         )
                     )
 
             val npgCorrelationId = WALLET_UUID.value
+
             val npgCreateHostedOrderRequest =
                 CreateHostedOrderRequest()
                     .version(WalletService.CREATE_HOSTED_ORDER_REQUEST_VERSION)
@@ -862,7 +866,7 @@ class WalletServiceTest {
                         walletIdAsClaim = any()
                     )
                 }
-                .willAnswer { Either.right<JWTTokenGenerationException, String>("token") }
+                .willAnswer { Either.right<JWTTokenGenerationException, String>(sessionToken) }
             /* test */
             StepVerifier.create(
                     walletService.createSessionWallet(
@@ -967,6 +971,7 @@ class WalletServiceTest {
             val merchantUrl = sessionUrlConfig.basePath
             val resultUrl = basePath.resolve(sessionUrlConfig.outcomeSuffix)
             val cancelUrl = basePath.resolve(sessionUrlConfig.cancelSuffix)
+            val sessionToken = "sessionToken"
             val notificationUrl =
                 UriComponentsBuilder.fromHttpUrl(
                         sessionUrlConfig.trxWithContextualOnboardNotificationUrl
@@ -979,7 +984,7 @@ class WalletServiceTest {
                                 walletDocumentCreatedStatusForTransactionWithContextualOnboard.id
                             ),
                             Pair("orderId", orderId),
-                            Pair("sessionToken", "token")
+                            Pair("sessionToken", sessionToken)
                         )
                     )
 
@@ -1031,7 +1036,7 @@ class WalletServiceTest {
                         walletIdAsClaim = any()
                     )
                 }
-                .willAnswer { Either.right<JWTTokenGenerationException, String>("token") }
+                .willAnswer { Either.right<JWTTokenGenerationException, String>(sessionToken) }
 
             given { npgSessionRedisTemplate.save(any()) }.willAnswer { mono { npgSession } }
             /* test */
@@ -1087,7 +1092,7 @@ class WalletServiceTest {
                 walletDocumentValidationRequestedStatus(PAYMENT_METHOD_ID_APM)
 
             val walletDocumentCreatedStatus = walletDocumentCreatedStatus(PAYMENT_METHOD_ID_APM)
-
+            val sessionToken = "sessionToken"
             val basePath = URI.create(sessionUrlConfig.basePath)
             val merchantUrl = sessionUrlConfig.basePath
             val resultUrl = basePath.resolve(sessionUrlConfig.outcomeSuffix)
@@ -1098,6 +1103,7 @@ class WalletServiceTest {
                         mapOf(
                             Pair("walletId", walletDocumentCreatedStatus.id),
                             Pair("orderId", orderId),
+                            Pair("sessionToken", sessionToken)
                         )
                     )
 
@@ -1152,7 +1158,7 @@ class WalletServiceTest {
                         walletIdAsClaim = any()
                     )
                 }
-                .willAnswer { Either.right<JWTTokenGenerationException, String>("token") }
+                .willAnswer { Either.right<JWTTokenGenerationException, String>(sessionToken) }
             /* test */
             StepVerifier.create(
                     walletService.createSessionWallet(
@@ -1215,12 +1221,14 @@ class WalletServiceTest {
             val merchantUrl = sessionUrlConfig.basePath
             val resultUrl = basePath.resolve(sessionUrlConfig.outcomeSuffix)
             val cancelUrl = basePath.resolve(sessionUrlConfig.cancelSuffix)
+            val sessionToken = "sessionToken"
             val notificationUrl =
                 UriComponentsBuilder.fromHttpUrl(sessionUrlConfig.notificationUrl)
                     .build(
                         mapOf(
                             Pair("walletId", walletDocumentCreatedStatus.id),
                             Pair("orderId", orderId),
+                            Pair("sessionToken", sessionToken)
                         )
                     )
 
@@ -1271,7 +1279,7 @@ class WalletServiceTest {
                         walletIdAsClaim = any()
                     )
                 }
-                .willAnswer { Either.right<JWTTokenGenerationException, String>("token") }
+                .willAnswer { Either.right<JWTTokenGenerationException, String>(sessionToken) }
             /* test */
             StepVerifier.create(
                     walletService.createSessionWallet(
@@ -1348,15 +1356,16 @@ class WalletServiceTest {
             val merchantUrl = sessionUrlConfig.basePath
             val resultUrl = basePath.resolve(sessionUrlConfig.outcomeSuffix)
             val cancelUrl = basePath.resolve(sessionUrlConfig.cancelSuffix)
+            val sessionToken = "sessionToken"
             val notificationUrl =
                 UriComponentsBuilder.fromHttpUrl(sessionUrlConfig.notificationUrl)
                     .build(
                         mapOf(
                             Pair("walletId", walletDocumentCreatedStatus.id),
                             Pair("orderId", orderId),
+                            Pair("sessionToken", sessionToken)
                         )
                     )
-
             val npgCreateHostedOrderRequest =
                 CreateHostedOrderRequest()
                     .version(WalletService.CREATE_HOSTED_ORDER_REQUEST_VERSION)
@@ -1407,7 +1416,7 @@ class WalletServiceTest {
                         walletIdAsClaim = any()
                     )
                 }
-                .willAnswer { Either.right<JWTTokenGenerationException, String>("token") }
+                .willAnswer { Either.right<JWTTokenGenerationException, String>(sessionToken) }
             /* test */
             StepVerifier.create(
                     walletService.createSessionWallet(
@@ -3759,7 +3768,7 @@ class WalletServiceTest {
                 NpgSession(orderId, sessionId.toString(), "token", WALLET_UUID.value.toString())
 
             val walletDocumentCreatedStatus = walletDocumentCreatedStatus(PAYMENT_METHOD_ID_APM)
-
+            val sessionToken = "sessionToken"
             /* Mock response */
             given { ecommercePaymentMethodsClient.getPaymentMethodById(any()) }
                 .willAnswer { Mono.just(getValidAPMPaymentMethod()) }
@@ -3780,7 +3789,7 @@ class WalletServiceTest {
                         walletIdAsClaim = any()
                     )
                 }
-                .willAnswer { Either.right<JWTTokenGenerationException, String>("token") }
+                .willAnswer { Either.right<JWTTokenGenerationException, String>(sessionToken) }
             /* test */
             walletService
                 .createSessionWallet(USER_ID, WALLET_UUID, APM_SESSION_CREATE_REQUEST)
@@ -3841,6 +3850,581 @@ class WalletServiceTest {
             verify(walletRepository, times(1)).save(capture())
             assertEquals("Any Reason", lastValue.errorReason)
             assertEquals(WalletStatusDto.ERROR.name, lastValue.status)
+        }
+    }
+
+    @Test
+    fun `should allow re-create wallet session for CARD wallet in INITIALIZED status`() {
+        /* preconditions */
+
+        val uniqueId = getUniqueId()
+        val orderId = uniqueId
+        val contractId = uniqueId
+
+        mockStatic(Instant::class.java, Mockito.CALLS_REAL_METHODS).use { mockedStaticInstant ->
+            mockedStaticInstant.`when`<Instant> { Instant.now() }.thenReturn(mockedInstant)
+            val sessionId = UUID.randomUUID().toString()
+            val npgFields =
+                Fields()
+                    .sessionId(sessionId)
+                    .securityToken("token")
+                    .state(WorkflowState.GDI_VERIFICATION)
+                    .apply {
+                        fields =
+                            listOf(
+                                Field()
+                                    .id(UUID.randomUUID().toString())
+                                    .src("https://test.it/h")
+                                    .propertyClass("holder")
+                                    .propertyClass("h"),
+                                Field()
+                                    .id(UUID.randomUUID().toString())
+                                    .src("https://test.it/p")
+                                    .propertyClass("pan")
+                                    .propertyClass("p"),
+                                Field()
+                                    .id(UUID.randomUUID().toString())
+                                    .src("https://test.it/c")
+                                    .propertyClass("cvv")
+                                    .propertyClass("c")
+                            )
+                    }
+            val sessionResponseDto =
+                SessionWalletCreateResponseDto()
+                    .orderId(orderId)
+                    .sessionData(
+                        SessionWalletCreateResponseCardDataDto()
+                            .paymentMethodType("cards")
+                            .cardFormFields(
+                                npgFields.fields!!.map {
+                                    FieldDto()
+                                        .propertyClass(it.propertyClass)
+                                        .src(URI.create(it.src))
+                                        .id(it.id)
+                                }
+                            )
+                    )
+            given { ecommercePaymentMethodsClient.getPaymentMethodById(any()) }
+                .willAnswer { Mono.just(getValidCardsPaymentMethod()) }
+
+            given { uniqueIdUtils.generateUniqueId() }.willAnswer { Mono.just(uniqueId) }
+
+            val npgSession = NpgSession(orderId, sessionId, "token", WALLET_UUID.value.toString())
+
+            val walletDocumentInitialized = walletDocumentInitializedStatus(PAYMENT_METHOD_ID_CARDS)
+
+            val expectedLoggedAction =
+                LoggedAction(
+                    walletDocumentInitialized.toDomain(),
+                    SessionWalletCreatedEvent(WALLET_UUID.value.toString())
+                )
+
+            val basePath = URI.create(sessionUrlConfig.basePath)
+            val merchantUrl = sessionUrlConfig.basePath
+            val resultUrl = basePath.resolve(sessionUrlConfig.outcomeSuffix)
+            val cancelUrl = basePath.resolve(sessionUrlConfig.cancelSuffix)
+            val sessionToken = "sessionToken"
+            val notificationUrl =
+                UriComponentsBuilder.fromHttpUrl(sessionUrlConfig.notificationUrl)
+                    .build(
+                        mapOf(
+                            Pair("walletId", walletDocumentInitialized.id),
+                            Pair("orderId", orderId),
+                            Pair("sessionToken", sessionToken)
+                        )
+                    )
+
+            val npgCorrelationId = WALLET_UUID.value
+            val npgCreateHostedOrderRequest =
+                CreateHostedOrderRequest()
+                    .version(WalletService.CREATE_HOSTED_ORDER_REQUEST_VERSION)
+                    .merchantUrl(merchantUrl)
+                    .order(
+                        Order()
+                            .orderId(orderId)
+                            .amount(WalletService.CREATE_HOSTED_ORDER_REQUEST_VERIFY_AMOUNT)
+                            .currency(WalletService.CREATE_HOSTED_ORDER_REQUEST_CURRENCY_EUR)
+                    )
+                    .paymentSession(
+                        PaymentSession()
+                            .actionType(ActionType.VERIFY)
+                            .recurrence(
+                                RecurringSettings()
+                                    .action(RecurringAction.CONTRACT_CREATION)
+                                    .contractId(contractId)
+                                    .contractType(RecurringContractType.CIT)
+                            )
+                            .amount(WalletService.CREATE_HOSTED_ORDER_REQUEST_VERIFY_AMOUNT)
+                            .language(WalletService.CREATE_HOSTED_ORDER_REQUEST_LANGUAGE_ITA)
+                            .captureType(CaptureType.IMPLICIT)
+                            .paymentService("CARDS")
+                            .resultUrl(resultUrl.toString())
+                            .cancelUrl(cancelUrl.toString())
+                            .notificationUrl(notificationUrl.toString())
+                    )
+
+            given { npgClient.createNpgOrderBuild(any(), any(), anyOrNull()) }
+                .willAnswer { mono { npgFields } }
+
+            val walletArgumentCaptor: KArgumentCaptor<Wallet> = argumentCaptor()
+
+            given { walletRepository.findByIdAndUserId(any(), any()) }
+                .willReturn(Mono.just(walletDocumentInitialized))
+
+            given { walletRepository.save(walletArgumentCaptor.capture()) }
+                .willAnswer { Mono.just(it.arguments[0]) }
+
+            given {
+                    jwtTokenUtils.generateJwtTokenForNpgNotifications(
+                        transactionIdAsClaim = anyOrNull(),
+                        walletIdAsClaim = any()
+                    )
+                }
+                .willAnswer { Either.right<JWTTokenGenerationException, String>(sessionToken) }
+
+            given { npgSessionRedisTemplate.save(any()) }.willAnswer { mono { npgSession } }
+            /* test */
+            StepVerifier.create(
+                    walletService.createSessionWallet(
+                        USER_ID,
+                        WALLET_UUID,
+                        SessionInputCardDataDto()
+                    )
+                )
+                .assertNext { assertEquals((Pair(sessionResponseDto, expectedLoggedAction)), it) }
+                .verifyComplete()
+
+            verify(ecommercePaymentMethodsClient, times(1))
+                .getPaymentMethodById(PAYMENT_METHOD_ID_CARDS.value.toString())
+            verify(uniqueIdUtils, times(2)).generateUniqueId()
+            verify(walletRepository, times(1))
+                .findByIdAndUserId(WALLET_UUID.value.toString(), USER_ID.id.toString())
+            verify(npgClient, times(1))
+                .createNpgOrderBuild(npgCorrelationId, npgCreateHostedOrderRequest, null)
+            verify(npgSessionRedisTemplate, times(1)).save(npgSession)
+            verify(jwtTokenUtils, times(1))
+                .generateJwtTokenForNpgNotifications(
+                    transactionIdAsClaim = null,
+                    walletIdAsClaim = WALLET_UUID.value.toString()
+                )
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = WalletStatusDto::class,
+        mode = EnumSource.Mode.EXCLUDE,
+        names = ["CREATED", "INITIALIZED"]
+    )
+    fun `should deny re-create wallet session for CARD wallet in status different from CREATED and INITIALIZED`(
+        walletStatus: WalletStatusDto
+    ) {
+        /* preconditions */
+
+        mockStatic(Instant::class.java, Mockito.CALLS_REAL_METHODS).use { mockedStaticInstant ->
+            mockedStaticInstant.`when`<Instant> { Instant.now() }.thenReturn(mockedInstant)
+
+            given { ecommercePaymentMethodsClient.getPaymentMethodById(any()) }
+                .willAnswer { Mono.just(getValidCardsPaymentMethod()) }
+
+            val walletDocument =
+                walletDocumentInitializedStatus(PAYMENT_METHOD_ID_CARDS)
+                    .copy(status = walletStatus.value)
+
+            val sessionToken = "sessionToken"
+
+            val walletArgumentCaptor: KArgumentCaptor<Wallet> = argumentCaptor()
+
+            given { walletRepository.findByIdAndUserId(any(), any()) }
+                .willReturn(Mono.just(walletDocument))
+
+            given { walletRepository.save(walletArgumentCaptor.capture()) }
+                .willAnswer { Mono.just(it.arguments[0]) }
+
+            given {
+                    jwtTokenUtils.generateJwtTokenForNpgNotifications(
+                        transactionIdAsClaim = anyOrNull(),
+                        walletIdAsClaim = any()
+                    )
+                }
+                .willAnswer { Either.right<JWTTokenGenerationException, String>(sessionToken) }
+
+            /* test */
+            StepVerifier.create(
+                    walletService.createSessionWallet(
+                        USER_ID,
+                        WALLET_UUID,
+                        SessionInputCardDataDto()
+                    )
+                )
+                .expectErrorMatches {
+                    assertTrue(it is WalletConflictStatusException)
+                    assertEquals(
+                        "Conflict with walletId [${walletDocument.id}] with status [$walletStatus]. Allowed statuses [CREATED, INITIALIZED]",
+                        it.message
+                    )
+                    true
+                }
+                .verify()
+
+            verify(ecommercePaymentMethodsClient, times(1))
+                .getPaymentMethodById(PAYMENT_METHOD_ID_CARDS.value.toString())
+            verify(uniqueIdUtils, times(0)).generateUniqueId()
+            verify(walletRepository, times(1))
+                .findByIdAndUserId(WALLET_UUID.value.toString(), USER_ID.id.toString())
+            verify(npgClient, times(0)).createNpgOrderBuild(any(), any(), anyOrNull())
+            verify(npgSessionRedisTemplate, times(0)).save(any())
+            verify(jwtTokenUtils, times(0))
+                .generateJwtTokenForNpgNotifications(
+                    transactionIdAsClaim = anyOrNull(),
+                    walletIdAsClaim = any()
+                )
+        }
+    }
+
+    @Test
+    fun `should allow re-create wallet session for APM wallet in VALIDATION_REQUESTED status`() {
+        /* preconditions */
+
+        val uniqueId = getUniqueId()
+        val orderId = uniqueId
+        val contractId = uniqueId
+
+        mockStatic(Instant::class.java, Mockito.CALLS_REAL_METHODS).use { mockedStaticInstant ->
+            mockedStaticInstant.`when`<Instant> { Instant.now() }.thenReturn(mockedInstant)
+            val sessionId = UUID.randomUUID().toString()
+            val apmRedirectUrl = "https://apm-url"
+            val npgFields =
+                Fields()
+                    .sessionId(sessionId)
+                    .securityToken("token")
+                    .url(apmRedirectUrl)
+                    .state(WorkflowState.REDIRECTED_TO_EXTERNAL_DOMAIN)
+
+            val sessionResponseDto =
+                SessionWalletCreateResponseDto()
+                    .orderId(orderId)
+                    .sessionData(
+                        SessionWalletCreateResponseAPMDataDto()
+                            .redirectUrl(apmRedirectUrl)
+                            .paymentMethodType("apm")
+                    )
+            given { ecommercePaymentMethodsClient.getPaymentMethodById(any()) }
+                .willAnswer { Mono.just(getValidAPMPaymentMethod()) }
+
+            given { uniqueIdUtils.generateUniqueId() }.willAnswer { Mono.just(uniqueId) }
+
+            val npgSession = NpgSession(orderId, sessionId, "token", WALLET_UUID.value.toString())
+
+            val walletDocumentValidationRequested =
+                walletDocumentValidationRequestedStatus(PAYMENT_METHOD_ID_APM)
+
+            val expectedLoggedAction =
+                LoggedAction(
+                    walletDocumentValidationRequested.toDomain(),
+                    SessionWalletCreatedEvent(WALLET_UUID.value.toString())
+                )
+
+            val basePath = URI.create(sessionUrlConfig.basePath)
+            val merchantUrl = sessionUrlConfig.basePath
+            val resultUrl = basePath.resolve(sessionUrlConfig.outcomeSuffix)
+            val cancelUrl = basePath.resolve(sessionUrlConfig.cancelSuffix)
+            val sessionToken = "sessionToken"
+            val notificationUrl =
+                UriComponentsBuilder.fromHttpUrl(sessionUrlConfig.notificationUrl)
+                    .build(
+                        mapOf(
+                            Pair("walletId", walletDocumentValidationRequested.id),
+                            Pair("orderId", orderId),
+                            Pair("sessionToken", sessionToken)
+                        )
+                    )
+
+            val npgCorrelationId = WALLET_UUID.value
+            val npgCreateHostedOrderRequest =
+                CreateHostedOrderRequest()
+                    .version(WalletService.CREATE_HOSTED_ORDER_REQUEST_VERSION)
+                    .merchantUrl(merchantUrl)
+                    .order(
+                        Order()
+                            .orderId(orderId)
+                            .amount(WalletService.CREATE_HOSTED_ORDER_REQUEST_VERIFY_AMOUNT)
+                            .currency(WalletService.CREATE_HOSTED_ORDER_REQUEST_CURRENCY_EUR)
+                    )
+                    .paymentSession(
+                        PaymentSession()
+                            .actionType(ActionType.VERIFY)
+                            .recurrence(
+                                RecurringSettings()
+                                    .action(RecurringAction.CONTRACT_CREATION)
+                                    .contractId(contractId)
+                                    .contractType(RecurringContractType.CIT)
+                            )
+                            .amount(WalletService.CREATE_HOSTED_ORDER_REQUEST_VERIFY_AMOUNT)
+                            .language(WalletService.CREATE_HOSTED_ORDER_REQUEST_LANGUAGE_ITA)
+                            .captureType(CaptureType.IMPLICIT)
+                            .paymentService("PAYPAL")
+                            .resultUrl(resultUrl.toString())
+                            .cancelUrl(cancelUrl.toString())
+                            .notificationUrl(notificationUrl.toString())
+                    )
+
+            given { npgClient.createNpgOrderBuild(any(), any(), anyOrNull()) }
+                .willAnswer { mono { npgFields } }
+
+            val walletArgumentCaptor: KArgumentCaptor<Wallet> = argumentCaptor()
+
+            given { walletRepository.findByIdAndUserId(any(), any()) }
+                .willReturn(Mono.just(walletDocumentValidationRequested))
+
+            given { walletRepository.save(walletArgumentCaptor.capture()) }
+                .willAnswer { Mono.just(it.arguments[0]) }
+
+            given {
+                    jwtTokenUtils.generateJwtTokenForNpgNotifications(
+                        transactionIdAsClaim = anyOrNull(),
+                        walletIdAsClaim = any()
+                    )
+                }
+                .willAnswer { Either.right<JWTTokenGenerationException, String>(sessionToken) }
+
+            given { npgSessionRedisTemplate.save(any()) }.willAnswer { mono { npgSession } }
+            /* test */
+            StepVerifier.create(
+                    walletService.createSessionWallet(
+                        USER_ID,
+                        WALLET_UUID,
+                        SessionInputCardDataDto()
+                    )
+                )
+                .assertNext { assertEquals((Pair(sessionResponseDto, expectedLoggedAction)), it) }
+                .verifyComplete()
+
+            verify(ecommercePaymentMethodsClient, times(1))
+                .getPaymentMethodById(PAYMENT_METHOD_ID_APM.value.toString())
+            verify(uniqueIdUtils, times(2)).generateUniqueId()
+            verify(walletRepository, times(1))
+                .findByIdAndUserId(WALLET_UUID.value.toString(), USER_ID.id.toString())
+            verify(npgClient, times(1))
+                .createNpgOrderBuild(npgCorrelationId, npgCreateHostedOrderRequest, null)
+            verify(npgSessionRedisTemplate, times(1)).save(npgSession)
+            verify(jwtTokenUtils, times(1))
+                .generateJwtTokenForNpgNotifications(
+                    transactionIdAsClaim = null,
+                    walletIdAsClaim = WALLET_UUID.value.toString()
+                )
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = WalletStatusDto::class,
+        mode = EnumSource.Mode.EXCLUDE,
+        names = ["CREATED", "VALIDATION_REQUESTED"]
+    )
+    fun `should deny re-create wallet session for APM wallet in status different from CREATED and VALIDATION_REQUESTED`(
+        walletStatus: WalletStatusDto
+    ) {
+        /* preconditions */
+
+        mockStatic(Instant::class.java, Mockito.CALLS_REAL_METHODS).use { mockedStaticInstant ->
+            mockedStaticInstant.`when`<Instant> { Instant.now() }.thenReturn(mockedInstant)
+
+            given { ecommercePaymentMethodsClient.getPaymentMethodById(any()) }
+                .willAnswer { Mono.just(getValidAPMPaymentMethod()) }
+
+            val walletDocument =
+                walletDocumentInitializedStatus(PAYMENT_METHOD_ID_APM)
+                    .copy(status = walletStatus.value)
+
+            val sessionToken = "sessionToken"
+
+            val walletArgumentCaptor: KArgumentCaptor<Wallet> = argumentCaptor()
+
+            given { walletRepository.findByIdAndUserId(any(), any()) }
+                .willReturn(Mono.just(walletDocument))
+
+            given { walletRepository.save(walletArgumentCaptor.capture()) }
+                .willAnswer { Mono.just(it.arguments[0]) }
+
+            given {
+                    jwtTokenUtils.generateJwtTokenForNpgNotifications(
+                        transactionIdAsClaim = anyOrNull(),
+                        walletIdAsClaim = any()
+                    )
+                }
+                .willAnswer { Either.right<JWTTokenGenerationException, String>(sessionToken) }
+
+            /* test */
+            StepVerifier.create(
+                    walletService.createSessionWallet(
+                        USER_ID,
+                        WALLET_UUID,
+                        SessionInputCardDataDto()
+                    )
+                )
+                .expectErrorMatches {
+                    assertTrue(it is WalletConflictStatusException)
+                    assertEquals(
+                        "Conflict with walletId [${walletDocument.id}] with status [$walletStatus]. Allowed statuses [CREATED, VALIDATION_REQUESTED]",
+                        it.message
+                    )
+                    true
+                }
+                .verify()
+
+            verify(ecommercePaymentMethodsClient, times(1))
+                .getPaymentMethodById(PAYMENT_METHOD_ID_APM.value.toString())
+            verify(uniqueIdUtils, times(0)).generateUniqueId()
+            verify(walletRepository, times(1))
+                .findByIdAndUserId(WALLET_UUID.value.toString(), USER_ID.id.toString())
+            verify(npgClient, times(0)).createNpgOrderBuild(any(), any(), anyOrNull())
+            verify(npgSessionRedisTemplate, times(0)).save(any())
+            verify(jwtTokenUtils, times(0))
+                .generateJwtTokenForNpgNotifications(
+                    transactionIdAsClaim = anyOrNull(),
+                    walletIdAsClaim = any()
+                )
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = WalletStatusDto::class, mode = EnumSource.Mode.EXCLUDE, names = ["CREATED"])
+    fun `should deny re-create wallet session for CARD wallet with contextual onboarding in status different than CREATED`(
+        walletStatus: WalletStatusDto
+    ) {
+        /* preconditions */
+
+        mockStatic(Instant::class.java, Mockito.CALLS_REAL_METHODS).use { mockedStaticInstant ->
+            mockedStaticInstant.`when`<Instant> { Instant.now() }.thenReturn(mockedInstant)
+
+            given { ecommercePaymentMethodsClient.getPaymentMethodById(any()) }
+                .willAnswer { Mono.just(getValidCardsPaymentMethod()) }
+
+            val walletDocument =
+                walletDocumentCreatedStatusForTransactionWithContextualOnboard(
+                        PAYMENT_METHOD_ID_CARDS
+                    )
+                    .copy(status = walletStatus.value)
+
+            val sessionToken = "sessionToken"
+
+            val walletArgumentCaptor: KArgumentCaptor<Wallet> = argumentCaptor()
+
+            given { walletRepository.findByIdAndUserId(any(), any()) }
+                .willReturn(Mono.just(walletDocument))
+
+            given { walletRepository.save(walletArgumentCaptor.capture()) }
+                .willAnswer { Mono.just(it.arguments[0]) }
+
+            given {
+                    jwtTokenUtils.generateJwtTokenForNpgNotifications(
+                        transactionIdAsClaim = anyOrNull(),
+                        walletIdAsClaim = any()
+                    )
+                }
+                .willAnswer { Either.right<JWTTokenGenerationException, String>(sessionToken) }
+
+            /* test */
+            StepVerifier.create(
+                    walletService.createSessionWallet(
+                        USER_ID,
+                        WALLET_UUID,
+                        SessionInputCardDataDto()
+                    )
+                )
+                .expectErrorMatches {
+                    assertTrue(it is WalletConflictStatusException)
+                    assertEquals(
+                        "Conflict with walletId [${walletDocument.id}] with status [$walletStatus]. Allowed statuses [CREATED]",
+                        it.message
+                    )
+                    true
+                }
+                .verify()
+
+            verify(ecommercePaymentMethodsClient, times(1))
+                .getPaymentMethodById(PAYMENT_METHOD_ID_CARDS.value.toString())
+            verify(uniqueIdUtils, times(0)).generateUniqueId()
+            verify(walletRepository, times(1))
+                .findByIdAndUserId(WALLET_UUID.value.toString(), USER_ID.id.toString())
+            verify(npgClient, times(0)).createNpgOrderBuild(any(), any(), anyOrNull())
+            verify(npgSessionRedisTemplate, times(0)).save(any())
+            verify(jwtTokenUtils, times(0))
+                .generateJwtTokenForNpgNotifications(
+                    transactionIdAsClaim = anyOrNull(),
+                    walletIdAsClaim = any()
+                )
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = WalletStatusDto::class, mode = EnumSource.Mode.EXCLUDE, names = ["CREATED"])
+    fun `should deny re-create wallet session for APM wallet with contextual onboarding in status different than CREATED`(
+        walletStatus: WalletStatusDto
+    ) {
+        /* preconditions */
+
+        mockStatic(Instant::class.java, Mockito.CALLS_REAL_METHODS).use { mockedStaticInstant ->
+            mockedStaticInstant.`when`<Instant> { Instant.now() }.thenReturn(mockedInstant)
+
+            given { ecommercePaymentMethodsClient.getPaymentMethodById(any()) }
+                .willAnswer { Mono.just(getValidAPMPaymentMethod()) }
+
+            val walletDocument =
+                walletDocumentCreatedStatusForTransactionWithContextualOnboard(
+                        PAYMENT_METHOD_ID_APM
+                    )
+                    .copy(status = walletStatus.value)
+
+            val sessionToken = "sessionToken"
+
+            val walletArgumentCaptor: KArgumentCaptor<Wallet> = argumentCaptor()
+
+            given { walletRepository.findByIdAndUserId(any(), any()) }
+                .willReturn(Mono.just(walletDocument))
+
+            given { walletRepository.save(walletArgumentCaptor.capture()) }
+                .willAnswer { Mono.just(it.arguments[0]) }
+
+            given {
+                    jwtTokenUtils.generateJwtTokenForNpgNotifications(
+                        transactionIdAsClaim = anyOrNull(),
+                        walletIdAsClaim = any()
+                    )
+                }
+                .willAnswer { Either.right<JWTTokenGenerationException, String>(sessionToken) }
+
+            /* test */
+            StepVerifier.create(
+                    walletService.createSessionWallet(
+                        USER_ID,
+                        WALLET_UUID,
+                        SessionInputCardDataDto()
+                    )
+                )
+                .expectErrorMatches {
+                    assertTrue(it is WalletConflictStatusException)
+                    assertEquals(
+                        "Conflict with walletId [${walletDocument.id}] with status [$walletStatus]. Allowed statuses [CREATED]",
+                        it.message
+                    )
+                    true
+                }
+                .verify()
+
+            verify(ecommercePaymentMethodsClient, times(1))
+                .getPaymentMethodById(PAYMENT_METHOD_ID_APM.value.toString())
+            verify(uniqueIdUtils, times(0)).generateUniqueId()
+            verify(walletRepository, times(1))
+                .findByIdAndUserId(WALLET_UUID.value.toString(), USER_ID.id.toString())
+            verify(npgClient, times(0)).createNpgOrderBuild(any(), any(), anyOrNull())
+            verify(npgSessionRedisTemplate, times(0)).save(any())
+            verify(jwtTokenUtils, times(0))
+                .generateJwtTokenForNpgNotifications(
+                    transactionIdAsClaim = anyOrNull(),
+                    walletIdAsClaim = any()
+                )
         }
     }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Make POST session idempotent 
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification is needed in order to make POST session idempotent to wallet-fe to reload NPG card fields.
POST session have been make idempotent only for onboarding api calls and for payment with contextual onboarding since those api call are authorizative for APM (order/build api call)
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests + api tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
