### PR TITLE
fix: [CHK-3202] Added mae alias to maestro

### DIFF
--- a/src/main/kotlin/it/pagopa/wallet/domain/wallets/details/CardBrand.kt
+++ b/src/main/kotlin/it/pagopa/wallet/domain/wallets/details/CardBrand.kt
@@ -1,16 +1,13 @@
 package it.pagopa.wallet.domain.wallets.details
 
 class CardBrand(rawValue: String) {
-    val value: String
 
-    init {
-        value =
-            if (rawValue == "MC") {
-                "MASTERCARD"
-            } else {
-                rawValue
-            }
-    }
+    val value: String =
+        when (rawValue) {
+            "MC" -> "MASTERCARD"
+            "MAE" -> "MAESTRO"
+            else -> rawValue
+        }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/it/pagopa/wallet/services/WalletService.kt
+++ b/src/main/kotlin/it/pagopa/wallet/services/WalletService.kt
@@ -1034,7 +1034,7 @@ class WalletService(
                     .type(details.type)
                     .expiryDate(details.expiryDate)
                     .lastFourDigits(details.lastFourDigits)
-                    .brand(details.brand)
+                    .brand(CardBrand(details.brand).value)
             is PayPalDetailsDocument ->
                 WalletPaypalDetailsDto()
                     .maskedEmail(details.maskedEmail)
@@ -1067,7 +1067,7 @@ class WalletService(
         return WalletAuthDataDto()
             .walletId(UUID.fromString(wallet.id))
             .contractId(wallet.contractId)
-            .brand(brand)
+            .brand(CardBrand(brand).value)
             .paymentMethodData(paymentMethodData)
     }
 

--- a/src/test/kotlin/it/pagopa/wallet/util/WalletUtilsTest.kt
+++ b/src/test/kotlin/it/pagopa/wallet/util/WalletUtilsTest.kt
@@ -55,7 +55,7 @@ class WalletUtilsTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["MAE", "UNK", "OTHER"])
+    @ValueSource(strings = ["UNK", "OTHER"])
     fun `should fallback to unknown logo when brand is unknown`(unknownBrand: String) {
         val walletWithUnknownBrand =
             WalletTestUtils.walletDocumentStatusValidatedCard(CardBrand(unknownBrand)).toDomain()

--- a/src/test/kotlin/it/pagopa/wallet/util/WalletUtilsTest.kt
+++ b/src/test/kotlin/it/pagopa/wallet/util/WalletUtilsTest.kt
@@ -40,6 +40,19 @@ class WalletUtilsTest {
         assertTrue(logoURI.toString().endsWith("/${(wallet.details as CardDetails).brand.value}"))
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = ["MAE", "MC"])
+    fun `should retrieve right logo for brand alias`(brand: String) {
+        val walletWithAliasBrand =
+            WalletTestUtils.walletDocumentStatusValidatedCard(CardBrand(brand)).toDomain()
+        val logoURI = walletUtils.getLogo(walletWithAliasBrand)
+        assertTrue(
+            logoURI
+                .toString()
+                .endsWith("/${(walletWithAliasBrand.details as CardDetails).brand.value}")
+        )
+    }
+
     @Test
     fun `should retrieve logo for input apm wallet successfully`() {
         val wallet = WalletTestUtils.walletDocumentStatusValidatedAPM("test@test.it").toDomain()


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- added `MAE` to `MAESTRO` mapping to provide right brand naming and logo through api

<!--- Describe your changes in detail -->

#### Motivation and Context
APP IO reports incorrect mapping issues for logo and name for MAESTRO circuit

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
On DEV by onboarding MAESTRO card and changing brand to MAE on database document. Calling API, wallet now returns maestro and maestro logo for "MAE" brand

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
