### PR TITLE
feat: remove unused update wallet last usage logic

### DIFF
--- a/api-spec/wallet-api.yaml
+++ b/api-spec/wallet-api.yaml
@@ -955,9 +955,6 @@ components:
           $ref: '#/components/schemas/WalletApplicationId'
         status:
           $ref: '#/components/schemas/WalletApplicationStatus'
-        lastUsage:
-          type: string
-          format: date-time
       required:
         - name
         - status
@@ -1120,10 +1117,6 @@ components:
       properties:
         status:
           $ref: '#/components/schemas/WalletClientStatus'
-        lastUsage:
-          type: string
-          description: Time of last usage of this wallet by the client
-          format: date-time
       required:
         - status
     WalletInfo:

--- a/api-spec/wallet-api.yaml
+++ b/api-spec/wallet-api.yaml
@@ -690,47 +690,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemJson'
-  /wallets/{walletId}/usages:
-    patch:
-      tags:
-        - wallets
-      summary: Update last usage for wallet
-      operationId: updateWalletUsage
-      parameters:
-        - name: walletId
-          in: path
-          description: ID of wallet to return
-          required: true
-          schema:
-            $ref: '#/components/schemas/WalletId'
-      requestBody:
-        description: Usage input data
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                clientId:
-                  $ref: '#/components/schemas/ClientId'
-                usageTime:
-                  type: string
-                  format: date-time
-      responses:
-        '204':
-          description: Wallet update successfully
-        '400':
-          description: Invalid input id
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProblemJson'
-        '404':
-          description: Wallet not found
-        '422':
-          description: Client not present in wallet configuration
-        '504':
-          description: Timeout serving request
 
   /migrations/wallets:
     put:
@@ -979,17 +938,6 @@ components:
         failedApplications:
           - name: "PARI"
             status: "DISABLED"
-    Application:
-      type: object
-      properties:
-        name:
-          $ref: '#/components/schemas/ApplicationId'
-        status:
-          $ref: '#/components/schemas/ApplicationStatus'
-        updateDate:
-          description: Application last update date
-          type: string
-          format: date-time
     ApplicationId:
       description: Application identifier
       type: string

--- a/src/main/kotlin/it/pagopa/wallet/controllers/WalletController.kt
+++ b/src/main/kotlin/it/pagopa/wallet/controllers/WalletController.kt
@@ -296,18 +296,6 @@ class WalletController(
             .map { ResponseEntity.noContent().build() }
     }
 
-    override fun updateWalletUsage(
-        walletId: UUID,
-        updateWalletUsageRequestDto: Mono<UpdateWalletUsageRequestDto>,
-        exchange: ServerWebExchange?
-    ): Mono<ResponseEntity<Void>> {
-        return updateWalletUsageRequestDto
-            .flatMap {
-                walletService.updateWalletUsage(walletId, it.clientId, it.usageTime.toInstant())
-            }
-            .map { ResponseEntity.noContent().build() }
-    }
-
     override fun postWalletValidations(
         xUserId: UUID,
         walletId: UUID,
@@ -476,21 +464,6 @@ class WalletController(
                 "${WarmupUtils.WALLETS_ID_RESOURCE_URL}/auth-data",
                 mapOf("walletId" to WarmupUtils.mockedUUID)
             )
-            .retrieve()
-            .toBodilessEntity()
-            .block(Duration.ofSeconds(10))
-    }
-
-    @WarmupFunction
-    fun updateWalletUsage() {
-        webClient
-            .patch()
-            .uri(
-                "${WarmupUtils.WALLETS_ID_RESOURCE_URL}/usages",
-                mapOf("walletId" to WarmupUtils.mockedUUID)
-            )
-            .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue(WarmupUtils.updateWalletUsageRequestDto)
             .retrieve()
             .toBodilessEntity()
             .block(Duration.ofSeconds(10))

--- a/src/main/kotlin/it/pagopa/wallet/documents/wallets/Client.kt
+++ b/src/main/kotlin/it/pagopa/wallet/documents/wallets/Client.kt
@@ -1,9 +1,7 @@
 package it.pagopa.wallet.documents.wallets
 
 import it.pagopa.wallet.domain.wallets.Client
-import java.time.Instant
 
-data class Client(val status: String, val lastUsage: String?) {
-    fun toDomain(): Client =
-        Client(Client.Status.valueOf(status), lastUsage = lastUsage?.let { Instant.parse(it) })
+data class Client(val status: String) {
+    fun toDomain(): Client = Client(Client.Status.valueOf(status))
 }

--- a/src/main/kotlin/it/pagopa/wallet/domain/wallets/Client.kt
+++ b/src/main/kotlin/it/pagopa/wallet/domain/wallets/Client.kt
@@ -1,10 +1,9 @@
 package it.pagopa.wallet.domain.wallets
 
 import it.pagopa.wallet.documents.wallets.Client
-import java.time.Instant
 
-data class Client(val status: Status, val lastUsage: Instant?) {
-    fun toDocument(): Client = Client(status.name, lastUsage?.toString())
+data class Client(val status: Status) {
+    fun toDocument(): Client = Client(status.name)
 
     enum class Status {
         ENABLED,

--- a/src/main/kotlin/it/pagopa/wallet/services/MigrationService.kt
+++ b/src/main/kotlin/it/pagopa/wallet/services/MigrationService.kt
@@ -231,7 +231,7 @@ class MigrationService(
                     applications = listOf(application),
                     clients =
                         Client.WellKnown.values().associateWith { _ ->
-                            Client(Client.Status.ENABLED, null)
+                            Client(Client.Status.ENABLED)
                         },
                     creationDate = creationTime,
                     updateDate = creationTime,

--- a/src/main/kotlin/it/pagopa/wallet/services/WalletService.kt
+++ b/src/main/kotlin/it/pagopa/wallet/services/WalletService.kt
@@ -29,7 +29,6 @@ import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.YearMonth
-import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.*
 import kotlinx.coroutines.reactor.mono
@@ -166,8 +165,8 @@ class WalletService(
                             applications = apps,
                             version = 0,
                             clients =
-                                Client.WellKnown.values().associateWith { clientId ->
-                                    Client(Client.Status.ENABLED, null)
+                                Client.WellKnown.values().associateWith { _ ->
+                                    Client(Client.Status.ENABLED)
                                 },
                             creationDate = creationTime,
                             updateDate = creationTime,
@@ -257,8 +256,8 @@ class WalletService(
                             updateDate = creationTime,
                             applications = listOf(walletApplication),
                             clients =
-                                Client.WellKnown.values().associateWith { clientId ->
-                                    Client(Client.Status.ENABLED, null)
+                                Client.WellKnown.values().associateWith { _ ->
+                                    Client(Client.Status.ENABLED)
                                 },
                             onboardingChannel = onboardingChannel
                         ),
@@ -999,13 +998,6 @@ class WalletService(
                     WalletApplicationInfoDto()
                         .name(application.id)
                         .status(WalletApplicationStatusDto.valueOf(application.status))
-                        .lastUsage(
-                            wallet
-                                .toDomain()
-                                .clients[Client.WellKnown.IO]
-                                ?.lastUsage
-                                ?.atOffset(ZoneOffset.UTC)
-                        )
                 }
             )
             .clients(
@@ -1018,14 +1010,7 @@ class WalletService(
 
     private fun buildWalletClientDto(
         clientInfo: it.pagopa.wallet.documents.wallets.Client
-    ): WalletClientDto {
-        val walletClient =
-            WalletClientDto().status(WalletClientStatusDto.valueOf(clientInfo.status))
-        Optional.ofNullable(clientInfo.lastUsage).ifPresent { lastUsage ->
-            walletClient.lastUsage(OffsetDateTime.parse(lastUsage))
-        }
-        return walletClient
-    }
+    ): WalletClientDto = WalletClientDto().status(WalletClientStatusDto.valueOf(clientInfo.status))
 
     private fun toWalletInfoDetailsDto(details: WalletDetails<*>?): WalletInfoDetailsDto? {
         return when (details) {
@@ -1253,17 +1238,6 @@ class WalletService(
         } else {
             SessionWalletRetrieveResponseDto.OutcomeEnum.NUMBER_1
         }
-
-    private fun isWalletForTransactionWithContextualOnboard(
-        application: WalletApplication?
-    ): Boolean {
-        if (application != null) {
-            return application.metadata.data[
-                    WalletApplicationMetadata.Metadata.PAYMENT_WITH_CONTEXTUAL_ONBOARD]
-                .toBoolean()
-        }
-        return false
-    }
 
     private fun buildNotificationUrl(
         isTransactionWithContextualOnboard: Boolean,

--- a/src/main/kotlin/it/pagopa/wallet/services/WalletService.kt
+++ b/src/main/kotlin/it/pagopa/wallet/services/WalletService.kt
@@ -587,21 +587,6 @@ class WalletService(
             }
     }
 
-    fun updateWalletUsage(
-        walletId: UUID,
-        clientId: ClientIdDto,
-        usageTime: Instant
-    ): Mono<it.pagopa.wallet.documents.wallets.Wallet> =
-        walletRepository
-            .findById(walletId.toString())
-            .switchIfEmpty { Mono.error(WalletNotFoundException(WalletId(walletId))) }
-            .map { it.toDomain() }
-            .flatMap { it.expectInStatus(WalletStatusDto.VALIDATED).toMono() }
-            .flatMap {
-                walletRepository.save(it.updateUsageForClient(clientId, usageTime).toDocument())
-            }
-            .doOnNext { logger.info("Update last usage for walletId [{}]", it.id) }
-
     private fun confirmPaymentCard(
         sessionId: String,
         correlationId: UUID,

--- a/src/main/kotlin/it/pagopa/wallet/warmup/utils/WarmupUtils.kt
+++ b/src/main/kotlin/it/pagopa/wallet/warmup/utils/WarmupUtils.kt
@@ -40,12 +40,6 @@ object WarmupUtils {
                 }
         }
 
-    val updateWalletUsageRequestDto =
-        UpdateWalletUsageRequestDto().apply {
-            this.usageTime = OffsetDateTime.now()
-            this.clientId = ClientIdDto.IO
-        }
-
     val createTransactionWalletRequestDto =
         WalletTransactionCreateRequestDto().apply {
             this.amount = 0

--- a/src/test/kotlin/it/pagopa/wallet/WalletTestUtils.kt
+++ b/src/test/kotlin/it/pagopa/wallet/WalletTestUtils.kt
@@ -37,16 +37,10 @@ object WalletTestUtils {
     val VALIDATION_OPERATION_ID: UUID = UUID.randomUUID()
     val TEST_DEFAULT_CLIENTS: Map<Client.Id, Client> =
         mapOf(
-            Client.WellKnown.IO to Client(Client.Status.ENABLED, null),
-            Client.Unknown("unknownClient") to Client(Client.Status.DISABLED, null)
+            Client.WellKnown.IO to Client(Client.Status.ENABLED),
+            Client.Unknown("unknownClient") to Client(Client.Status.DISABLED)
         )
-    val TEST_FULL_INFO_CLIENTS: Map<Client.Id, Client> =
-        mapOf(
-            Client.WellKnown.IO to Client(Client.Status.ENABLED, Instant.now()),
-            Client.Unknown("unknownClient") to
-                Client(Client.Status.DISABLED, Instant.now().minusMillis(10000))
-        )
-    val APPLICATION_METADATA_HASHMAP: HashMap<String, String> = hashMapOf()
+    private val APPLICATION_METADATA_HASHMAP: HashMap<String, String> = hashMapOf()
     val APPLICATION_METADATA =
         WalletApplicationMetadata(
             APPLICATION_METADATA_HASHMAP.mapKeys {
@@ -107,7 +101,7 @@ object WalletTestUtils {
             details = null,
             clients =
                 mapOf(
-                    Client.WellKnown.IO.name to ClientDocument(Client.Status.ENABLED.name, null),
+                    Client.WellKnown.IO.name to ClientDocument(Client.Status.ENABLED.name),
                 ),
             version = 0,
             creationDate = creationDate,
@@ -156,8 +150,7 @@ object WalletTestUtils {
                                     Client.Status.ENABLED.name
                                 } else {
                                     Client.Status.DISABLED.name
-                                },
-                                null
+                                }
                             )
                     }
             )
@@ -391,58 +384,54 @@ object WalletTestUtils {
         brand: String,
         clients: Map<Client.Id, Client> = TEST_DEFAULT_CLIENTS
     ): Wallet {
-        val wallet =
-            Wallet(
-                id = WALLET_UUID.value.toString(),
-                userId = USER_ID.id.toString(),
-                status = WalletStatusDto.VALIDATION_REQUESTED.name,
-                paymentMethodId = PAYMENT_METHOD_ID_CARDS.value.toString(),
-                contractId = CONTRACT_ID.contractId,
-                validationOperationResult = null,
-                validationErrorCode = null,
-                errorReason = null,
-                applications = listOf(),
-                details =
-                    CardDetailsDocument(
-                        WalletDetailsType.CARDS.name,
-                        bin,
-                        lastFourDigits,
-                        expiryDate,
-                        brand,
-                        paymentInstrumentGatewayId
-                    ),
-                clients = clients.entries.associate { it.key.name to it.value.toDocument() },
-                version = 0,
-                creationDate = creationDate,
-                updateDate = creationDate,
-                onboardingChannel = OnboardingChannel.IO.toString()
-            )
-        return wallet
+        return Wallet(
+            id = WALLET_UUID.value.toString(),
+            userId = USER_ID.id.toString(),
+            status = WalletStatusDto.VALIDATION_REQUESTED.name,
+            paymentMethodId = PAYMENT_METHOD_ID_CARDS.value.toString(),
+            contractId = CONTRACT_ID.contractId,
+            validationOperationResult = null,
+            validationErrorCode = null,
+            errorReason = null,
+            applications = listOf(),
+            details =
+                CardDetailsDocument(
+                    WalletDetailsType.CARDS.name,
+                    bin,
+                    lastFourDigits,
+                    expiryDate,
+                    brand,
+                    paymentInstrumentGatewayId
+                ),
+            clients = clients.entries.associate { it.key.name to it.value.toDocument() },
+            version = 0,
+            creationDate = creationDate,
+            updateDate = creationDate,
+            onboardingChannel = OnboardingChannel.IO.toString()
+        )
     }
 
     fun walletDocumentVerifiedWithAPM(
         details: WalletDetails<*>,
         clients: Map<Client.Id, Client> = TEST_DEFAULT_CLIENTS
     ): Wallet {
-        val wallet =
-            Wallet(
-                id = WALLET_UUID.value.toString(),
-                userId = USER_ID.id.toString(),
-                status = WalletStatusDto.VALIDATION_REQUESTED.name,
-                paymentMethodId = PAYMENT_METHOD_ID_CARDS.value.toString(),
-                contractId = CONTRACT_ID.contractId,
-                validationOperationResult = null,
-                validationErrorCode = null,
-                errorReason = null,
-                applications = listOf(),
-                details = details,
-                clients = clients.entries.associate { it.key.name to it.value.toDocument() },
-                version = 0,
-                creationDate = creationDate,
-                updateDate = creationDate,
-                onboardingChannel = OnboardingChannel.IO.toString()
-            )
-        return wallet
+        return Wallet(
+            id = WALLET_UUID.value.toString(),
+            userId = USER_ID.id.toString(),
+            status = WalletStatusDto.VALIDATION_REQUESTED.name,
+            paymentMethodId = PAYMENT_METHOD_ID_CARDS.value.toString(),
+            contractId = CONTRACT_ID.contractId,
+            validationOperationResult = null,
+            validationErrorCode = null,
+            errorReason = null,
+            applications = listOf(),
+            details = details,
+            clients = clients.entries.associate { it.key.name to it.value.toDocument() },
+            version = 0,
+            creationDate = creationDate,
+            updateDate = creationDate,
+            onboardingChannel = OnboardingChannel.IO.toString()
+        )
     }
 
     fun walletDocumentWithError(
@@ -471,205 +460,190 @@ object WalletTestUtils {
     }
 
     fun walletDocumentValidated(clients: Map<Client.Id, Client> = TEST_DEFAULT_CLIENTS): Wallet {
-        val wallet =
-            Wallet(
-                id = WALLET_UUID.value.toString(),
-                userId = USER_ID.id.toString(),
-                status = WalletStatusDto.VALIDATED.name,
-                paymentMethodId = PAYMENT_METHOD_ID_CARDS.value.toString(),
-                contractId = CONTRACT_ID.contractId,
-                validationOperationResult = OperationResultEnum.EXECUTED.toString(),
-                validationErrorCode = null,
-                errorReason = null,
-                applications = listOf(),
-                details = null,
-                clients = clients.entries.associate { it.key.name to it.value.toDocument() },
-                version = 0,
-                creationDate = creationDate,
-                updateDate = creationDate,
-                onboardingChannel = OnboardingChannel.IO.toString()
-            )
-        return wallet
+        return Wallet(
+            id = WALLET_UUID.value.toString(),
+            userId = USER_ID.id.toString(),
+            status = WalletStatusDto.VALIDATED.name,
+            paymentMethodId = PAYMENT_METHOD_ID_CARDS.value.toString(),
+            contractId = CONTRACT_ID.contractId,
+            validationOperationResult = OperationResultEnum.EXECUTED.toString(),
+            validationErrorCode = null,
+            errorReason = null,
+            applications = listOf(),
+            details = null,
+            clients = clients.entries.associate { it.key.name to it.value.toDocument() },
+            version = 0,
+            creationDate = creationDate,
+            updateDate = creationDate,
+            onboardingChannel = OnboardingChannel.IO.toString()
+        )
     }
 
     fun walletDocumentEmptyCreatedStatus(): Wallet {
-        val wallet =
-            Wallet(
-                id = WALLET_UUID.value.toString(),
-                userId = USER_ID.id.toString(),
-                status = WalletStatusDto.CREATED.name,
-                paymentMethodId = PAYMENT_METHOD_ID_CARDS.value.toString(),
-                contractId = CONTRACT_ID.contractId,
-                validationOperationResult = null,
-                validationErrorCode = null,
-                errorReason = null,
-                applications = listOf(),
-                details = null,
-                clients =
-                    TEST_DEFAULT_CLIENTS.entries.associate { it.key.name to it.value.toDocument() },
-                version = 0,
-                creationDate = creationDate,
-                updateDate = creationDate,
-                onboardingChannel = OnboardingChannel.IO.toString()
-            )
-        return wallet
+        return Wallet(
+            id = WALLET_UUID.value.toString(),
+            userId = USER_ID.id.toString(),
+            status = WalletStatusDto.CREATED.name,
+            paymentMethodId = PAYMENT_METHOD_ID_CARDS.value.toString(),
+            contractId = CONTRACT_ID.contractId,
+            validationOperationResult = null,
+            validationErrorCode = null,
+            errorReason = null,
+            applications = listOf(),
+            details = null,
+            clients =
+                TEST_DEFAULT_CLIENTS.entries.associate { it.key.name to it.value.toDocument() },
+            version = 0,
+            creationDate = creationDate,
+            updateDate = creationDate,
+            onboardingChannel = OnboardingChannel.IO.toString()
+        )
     }
 
     fun walletDocumentEmptyApplicationsNullDetails(): Wallet {
-        val wallet =
-            Wallet(
-                id = WALLET_UUID.value.toString(),
-                userId = USER_ID.id.toString(),
-                status = WalletStatusDto.CREATED.name,
-                paymentMethodId = PAYMENT_METHOD_ID_CARDS.value.toString(),
-                contractId = CONTRACT_ID.contractId,
-                validationOperationResult = null,
-                validationErrorCode = null,
-                errorReason = null,
-                applications = listOf(),
-                details = null,
-                clients =
-                    TEST_DEFAULT_CLIENTS.entries.associate { it.key.name to it.value.toDocument() },
-                version = 0,
-                creationDate = creationDate,
-                updateDate = creationDate,
-                onboardingChannel = OnboardingChannel.IO.toString()
-            )
-        return wallet
+        return Wallet(
+            id = WALLET_UUID.value.toString(),
+            userId = USER_ID.id.toString(),
+            status = WalletStatusDto.CREATED.name,
+            paymentMethodId = PAYMENT_METHOD_ID_CARDS.value.toString(),
+            contractId = CONTRACT_ID.contractId,
+            validationOperationResult = null,
+            validationErrorCode = null,
+            errorReason = null,
+            applications = listOf(),
+            details = null,
+            clients =
+                TEST_DEFAULT_CLIENTS.entries.associate { it.key.name to it.value.toDocument() },
+            version = 0,
+            creationDate = creationDate,
+            updateDate = creationDate,
+            onboardingChannel = OnboardingChannel.IO.toString()
+        )
     }
 
     fun walletDocumentEmptyContractId(): Wallet {
-        val wallet =
-            Wallet(
-                id = WALLET_UUID.value.toString(),
-                userId = USER_ID.id.toString(),
-                status = WalletStatusDto.CREATED.name,
-                paymentMethodId = PAYMENT_METHOD_ID_CARDS.value.toString(),
-                contractId = null,
-                validationOperationResult = null,
-                validationErrorCode = null,
-                errorReason = null,
-                applications = listOf(),
-                details = null,
-                clients =
-                    TEST_DEFAULT_CLIENTS.entries.associate { it.key.name to it.value.toDocument() },
-                version = 0,
-                creationDate = creationDate,
-                updateDate = creationDate,
-                onboardingChannel = OnboardingChannel.IO.toString()
-            )
-        return wallet
+        return Wallet(
+            id = WALLET_UUID.value.toString(),
+            userId = USER_ID.id.toString(),
+            status = WalletStatusDto.CREATED.name,
+            paymentMethodId = PAYMENT_METHOD_ID_CARDS.value.toString(),
+            contractId = null,
+            validationOperationResult = null,
+            validationErrorCode = null,
+            errorReason = null,
+            applications = listOf(),
+            details = null,
+            clients =
+                TEST_DEFAULT_CLIENTS.entries.associate { it.key.name to it.value.toDocument() },
+            version = 0,
+            creationDate = creationDate,
+            updateDate = creationDate,
+            onboardingChannel = OnboardingChannel.IO.toString()
+        )
     }
 
     fun walletDocumentWithEmptyValidationOperationResult(): Wallet {
-        val wallet =
-            Wallet(
-                id = WALLET_UUID.value.toString(),
-                userId = USER_ID.id.toString(),
-                status = WalletStatusDto.CREATED.name,
-                paymentMethodId = PAYMENT_METHOD_ID_CARDS.value.toString(),
-                contractId = null,
-                validationOperationResult = OperationResultEnum.EXECUTED.value,
-                validationErrorCode = null,
-                errorReason = null,
-                applications = listOf(),
-                details = null,
-                clients =
-                    TEST_DEFAULT_CLIENTS.entries.associate { it.key.name to it.value.toDocument() },
-                version = 0,
-                creationDate = creationDate,
-                updateDate = creationDate,
-                onboardingChannel = OnboardingChannel.IO.toString()
-            )
-        return wallet
+        return Wallet(
+            id = WALLET_UUID.value.toString(),
+            userId = USER_ID.id.toString(),
+            status = WalletStatusDto.CREATED.name,
+            paymentMethodId = PAYMENT_METHOD_ID_CARDS.value.toString(),
+            contractId = null,
+            validationOperationResult = OperationResultEnum.EXECUTED.value,
+            validationErrorCode = null,
+            errorReason = null,
+            applications = listOf(),
+            details = null,
+            clients =
+                TEST_DEFAULT_CLIENTS.entries.associate { it.key.name to it.value.toDocument() },
+            version = 0,
+            creationDate = creationDate,
+            updateDate = creationDate,
+            onboardingChannel = OnboardingChannel.IO.toString()
+        )
     }
 
     fun walletDocumentNullDetails(): Wallet {
-        val wallet =
-            Wallet(
-                id = WALLET_UUID.value.toString(),
-                userId = USER_ID.id.toString(),
-                status = WalletStatusDto.CREATED.name,
-                paymentMethodId = PAYMENT_METHOD_ID_CARDS.value.toString(),
-                contractId = CONTRACT_ID.contractId,
-                validationOperationResult = null,
-                validationErrorCode = null,
-                errorReason = null,
-                applications =
-                    listOf(
-                        WalletApplicationDocument(
-                            WALLET_APPLICATION_ID.id,
-                            WalletApplicationStatus.DISABLED.toString(),
-                            TIMESTAMP.toString(),
-                            TIMESTAMP.toString(),
-                            APPLICATION_METADATA.data.mapKeys { it.key.value }
-                        )
-                    ),
-                details = null,
-                clients =
-                    TEST_DEFAULT_CLIENTS.entries.associate { it.key.name to it.value.toDocument() },
-                version = 0,
-                creationDate = creationDate,
-                updateDate = creationDate,
-                onboardingChannel = OnboardingChannel.IO.toString()
-            )
-        return wallet
+        return Wallet(
+            id = WALLET_UUID.value.toString(),
+            userId = USER_ID.id.toString(),
+            status = WalletStatusDto.CREATED.name,
+            paymentMethodId = PAYMENT_METHOD_ID_CARDS.value.toString(),
+            contractId = CONTRACT_ID.contractId,
+            validationOperationResult = null,
+            validationErrorCode = null,
+            errorReason = null,
+            applications =
+                listOf(
+                    WalletApplicationDocument(
+                        WALLET_APPLICATION_ID.id,
+                        WalletApplicationStatus.DISABLED.toString(),
+                        TIMESTAMP.toString(),
+                        TIMESTAMP.toString(),
+                        APPLICATION_METADATA.data.mapKeys { it.key.value }
+                    )
+                ),
+            details = null,
+            clients =
+                TEST_DEFAULT_CLIENTS.entries.associate { it.key.name to it.value.toDocument() },
+            version = 0,
+            creationDate = creationDate,
+            updateDate = creationDate,
+            onboardingChannel = OnboardingChannel.IO.toString()
+        )
     }
 
     fun walletDomain(): it.pagopa.wallet.domain.wallets.Wallet {
-        val wallet = WALLET_DOMAIN
-        return wallet
+        return WALLET_DOMAIN
     }
 
     fun walletDocument(): Wallet {
-        val wallet =
-            Wallet(
-                id = WALLET_UUID.value.toString(),
-                userId = USER_ID.id.toString(),
-                status = WalletStatusDto.CREATED.name,
-                paymentMethodId = PAYMENT_METHOD_ID_CARDS.value.toString(),
-                contractId = CONTRACT_ID.contractId,
-                validationOperationResult = OperationResultEnum.EXECUTED.value,
-                validationErrorCode = null,
-                errorReason = null,
-                applications =
-                    listOf(
-                        WalletApplicationDocument(
-                            WALLET_APPLICATION_ID.id,
-                            WalletApplicationStatus.DISABLED.toString(),
-                            TIMESTAMP.toString(),
-                            TIMESTAMP.toString(),
-                            APPLICATION_METADATA_HASHMAP
-                        ),
-                        WalletApplicationDocument(
-                            OTHER_WALLET_APPLICATION_ID.id,
-                            WalletApplicationStatus.DISABLED.toString(),
-                            TIMESTAMP.toString(),
-                            TIMESTAMP.toString(),
-                            mapOf()
-                        )
+        return Wallet(
+            id = WALLET_UUID.value.toString(),
+            userId = USER_ID.id.toString(),
+            status = WalletStatusDto.CREATED.name,
+            paymentMethodId = PAYMENT_METHOD_ID_CARDS.value.toString(),
+            contractId = CONTRACT_ID.contractId,
+            validationOperationResult = OperationResultEnum.EXECUTED.value,
+            validationErrorCode = null,
+            errorReason = null,
+            applications =
+                listOf(
+                    WalletApplicationDocument(
+                        WALLET_APPLICATION_ID.id,
+                        WalletApplicationStatus.DISABLED.toString(),
+                        TIMESTAMP.toString(),
+                        TIMESTAMP.toString(),
+                        APPLICATION_METADATA_HASHMAP
                     ),
-                details =
-                    CardDetailsDocument(
-                        TYPE.toString(),
-                        BIN.bin,
-                        LAST_FOUR_DIGITS.lastFourDigits,
-                        EXP_DATE.expDate,
-                        BRAND.value,
-                        PAYMENT_INSTRUMENT_GATEWAY_ID.paymentInstrumentGatewayId
-                    ),
-                clients =
-                    TEST_DEFAULT_CLIENTS.entries.associate { it.key.name to it.value.toDocument() },
-                version = 0,
-                creationDate = creationDate,
-                updateDate = creationDate,
-                onboardingChannel = OnboardingChannel.IO.toString()
-            )
-        return wallet
+                    WalletApplicationDocument(
+                        OTHER_WALLET_APPLICATION_ID.id,
+                        WalletApplicationStatus.DISABLED.toString(),
+                        TIMESTAMP.toString(),
+                        TIMESTAMP.toString(),
+                        mapOf()
+                    )
+                ),
+            details =
+                CardDetailsDocument(
+                    TYPE.toString(),
+                    BIN.bin,
+                    LAST_FOUR_DIGITS.lastFourDigits,
+                    EXP_DATE.expDate,
+                    BRAND.value,
+                    PAYMENT_INSTRUMENT_GATEWAY_ID.paymentInstrumentGatewayId
+                ),
+            clients =
+                TEST_DEFAULT_CLIENTS.entries.associate { it.key.name to it.value.toDocument() },
+            version = 0,
+            creationDate = creationDate,
+            updateDate = creationDate,
+            onboardingChannel = OnboardingChannel.IO.toString()
+        )
     }
 
     val WALLET_DOMAIN =
-        it.pagopa.wallet.domain.wallets.Wallet(
+        Wallet(
             id = WALLET_UUID,
             userId = USER_ID,
             status = WalletStatusDto.CREATED,
@@ -705,27 +679,25 @@ object WalletTestUtils {
 
     fun walletDomainEmptyServicesNullDetailsNoPaymentInstrument():
         it.pagopa.wallet.domain.wallets.Wallet {
-        val wallet =
-            it.pagopa.wallet.domain.wallets.Wallet(
-                id = WALLET_UUID,
-                userId = USER_ID,
-                status = WalletStatusDto.CREATED,
-                paymentMethodId = PAYMENT_METHOD_ID_CARDS,
-                applications = listOf(),
-                contractId = CONTRACT_ID,
-                validationOperationResult = null,
-                validationErrorCode = null,
-                details = null,
-                clients = TEST_DEFAULT_CLIENTS,
-                version = 0,
-                creationDate = creationDate,
-                updateDate = creationDate,
-                onboardingChannel = OnboardingChannel.IO
-            )
-        return wallet
+        return Wallet(
+            id = WALLET_UUID,
+            userId = USER_ID,
+            status = WalletStatusDto.CREATED,
+            paymentMethodId = PAYMENT_METHOD_ID_CARDS,
+            applications = listOf(),
+            contractId = CONTRACT_ID,
+            validationOperationResult = null,
+            validationErrorCode = null,
+            details = null,
+            clients = TEST_DEFAULT_CLIENTS,
+            version = 0,
+            creationDate = creationDate,
+            updateDate = creationDate,
+            onboardingChannel = OnboardingChannel.IO
+        )
     }
 
-    fun walletInfoDto() =
+    fun walletInfoDto(): WalletInfoDto =
         WalletInfoDto()
             .walletId(WALLET_UUID.value)
             .status(WalletStatusDto.CREATED)
@@ -742,7 +714,7 @@ object WalletTestUtils {
                     .expiryDate(EXP_DATE.expDate)
             )
 
-    fun walletInfoDtoAPM() =
+    fun walletInfoDtoAPM(): WalletInfoDto =
         WalletInfoDto()
             .walletId(WALLET_UUID.value)
             .status(WalletStatusDto.CREATED)
@@ -755,14 +727,14 @@ object WalletTestUtils {
                 WalletPaypalDetailsDto().type("PAYPAL").maskedEmail("maskedEmail").pspId(PSP_ID)
             )
 
-    fun walletCardAuthDataDto() =
+    fun walletCardAuthDataDto(): WalletAuthDataDto =
         WalletAuthDataDto()
             .walletId(WALLET_UUID.value)
             .contractId(CONTRACT_ID.contractId)
             .brand(BRAND.value)
             .paymentMethodData(WalletAuthCardDataDto().bin(BIN.bin).paymentMethodType("cards"))
 
-    fun walletAPMAuthDataDto() =
+    fun walletAPMAuthDataDto(): WalletAuthDataDto =
         WalletAuthDataDto()
             .walletId(WALLET_UUID.value)
             .contractId(CONTRACT_ID.contractId)
@@ -806,7 +778,7 @@ object WalletTestUtils {
         WalletApplicationUpdateRequestDto().applications(listOf(WALLET_SERVICE_1, WALLET_SERVICE_2))
 
     val PSP_ID = UUID.randomUUID().toString()
-    val PSP_BUSINESS_NAME = "pspBusinessName"
+    const val PSP_BUSINESS_NAME = "pspBusinessName"
 
     val APM_SESSION_CREATE_REQUEST =
         SessionInputPayPalDataDto().apply {

--- a/src/test/kotlin/it/pagopa/wallet/config/SerializationConfigurationTest.kt
+++ b/src/test/kotlin/it/pagopa/wallet/config/SerializationConfigurationTest.kt
@@ -2,7 +2,6 @@ package it.pagopa.wallet.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import it.pagopa.generated.wallet.model.WalletClientDto
-import it.pagopa.generated.wallet.model.WalletClientStatusDto
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
@@ -15,7 +14,7 @@ class SerializationConfigurationTest {
 
     @Test
     fun shouldNotSerializeNullValues() {
-        val sampleObject = WalletClientDto().status(WalletClientStatusDto.ENABLED).lastUsage(null)
-        assertThat(objectMapper.writeValueAsString(sampleObject), not(containsString("lastUsage")))
+        val sampleObject = WalletClientDto().status(null)
+        assertThat(objectMapper.writeValueAsString(sampleObject), not(containsString("status")))
     }
 }

--- a/src/test/kotlin/it/pagopa/wallet/controllers/WalletControllerTest.kt
+++ b/src/test/kotlin/it/pagopa/wallet/controllers/WalletControllerTest.kt
@@ -25,7 +25,6 @@ import it.pagopa.wallet.services.WalletService
 import it.pagopa.wallet.util.UniqueIdUtils
 import java.net.URI
 import java.time.Instant
-import java.time.OffsetDateTime
 import java.util.*
 import kotlin.reflect.KClass
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -45,7 +44,6 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.dao.OptimisticLockingFailureException
 import org.springframework.http.HttpStatus
-import org.springframework.http.HttpStatusCode
 import org.springframework.http.MediaType
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.reactive.server.WebTestClient
@@ -53,7 +51,6 @@ import org.springframework.test.web.reactive.server.expectBody
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
-import reactor.kotlin.test.test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @WebFluxTest(WalletController::class)
@@ -1001,60 +998,6 @@ class WalletControllerTest {
                 exception.message
             )
         }
-
-    @Test
-    fun `should return 204 when update last wallet usage successfully`() = runTest {
-        val wallet = WalletTestUtils.walletDocument()
-        val updateRequest =
-            Mono.just(
-                UpdateWalletUsageRequestDto().clientId(ClientIdDto.IO).usageTime(OffsetDateTime.MIN)
-            )
-
-        given { walletService.updateWalletUsage(any(), any(), any()) }.willReturn(Mono.just(wallet))
-
-        walletController
-            .updateWalletUsage(
-                walletId = UUID.fromString(wallet.id),
-                updateWalletUsageRequestDto = updateRequest,
-                exchange = mock()
-            )
-            .test()
-            .assertNext {
-                assertEquals(HttpStatusCode.valueOf(204), it.statusCode)
-                verify(walletService)
-                    .updateWalletUsage(
-                        eq(UUID.fromString(wallet.id)),
-                        eq(ClientIdDto.IO),
-                        eq(OffsetDateTime.MIN.toInstant())
-                    )
-            }
-            .verifyComplete()
-    }
-
-    @Test
-    fun `should return 422 when update last wallet usage for non-configured client`() = runTest {
-        val wallet = WalletTestUtils.walletDocument()
-        val updateRequest =
-            UpdateWalletUsageRequestDto()
-                .clientId(ClientIdDto.CHECKOUT)
-                .usageTime(OffsetDateTime.MIN)
-
-        val error =
-            WalletClientConfigurationException(
-                WalletId(UUID.fromString(wallet.id)),
-                Client.Unknown("unknownClient")
-            )
-        given { walletService.updateWalletUsage(any(), any(), any()) }.willReturn(Mono.error(error))
-
-        webClient
-            .patch()
-            .uri("/wallets/{walletId}/usages", mapOf("walletId" to wallet.id))
-            .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue(updateRequest)
-            .exchange()
-            .expectStatus()
-            .isEqualTo(422)
-    }
 
     @Test
     fun `should return 409 when patch error state to wallet in non transient state`() {


### PR DESCRIPTION
Related infra PR to update lastUsage field as deprecated https://github.com/pagopa/pagopa-infra/pull/2489
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Remove wallet last usage api call logic
<!--- Describe your changes in detail -->

#### Motivation and Context
Those modifications are needed since wallet update last usage logic is unused and is superseded by wallet and payment method last usage information saved by eCommerce user-stats service
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
junit tests + local project build
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
