### PR TITLE
[MAIN-5] fix(delete-api): multiple delete

### DIFF
--- a/src/main/kotlin/it/pagopa/wallet/exception/WalletAlreadyDeletedException.kt
+++ b/src/main/kotlin/it/pagopa/wallet/exception/WalletAlreadyDeletedException.kt
@@ -6,5 +6,5 @@ import org.springframework.http.HttpStatus
 class WalletAlreadyDeletedException(val walletId: WalletId) :
     ApiError("Wallet with walletId [${walletId.value}] already deleted") {
     override fun toRestException(): RestApiException =
-        RestApiException(HttpStatus.CONFLICT, "Conflict", message!!)
+        RestApiException(HttpStatus.NO_CONTENT, "Already Deleted", message!!)
 }

--- a/src/main/kotlin/it/pagopa/wallet/exception/WalletAlreadyDeletedException.kt
+++ b/src/main/kotlin/it/pagopa/wallet/exception/WalletAlreadyDeletedException.kt
@@ -1,0 +1,10 @@
+package it.pagopa.wallet.exception
+
+import it.pagopa.wallet.domain.wallets.WalletId
+import org.springframework.http.HttpStatus
+
+class WalletAlreadyDeletedException(val walletId: WalletId) :
+    ApiError("Wallet with walletId [${walletId.value}] already deleted") {
+    override fun toRestException(): RestApiException =
+        RestApiException(HttpStatus.CONFLICT, "Conflict", message!!)
+}

--- a/src/main/kotlin/it/pagopa/wallet/exceptionhandler/ExceptionHandler.kt
+++ b/src/main/kotlin/it/pagopa/wallet/exceptionhandler/ExceptionHandler.kt
@@ -154,7 +154,7 @@ class ExceptionHandler(private val walletTracing: WalletTracing) {
     @ExceptionHandler(WalletAlreadyDeletedException::class)
     fun handleWalletAlreadyDeletedException(
         e: WalletAlreadyDeletedException
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         logger.error("Exception processing the request", e)
         return ResponseEntity.noContent().build()
     }

--- a/src/main/kotlin/it/pagopa/wallet/exceptionhandler/ExceptionHandler.kt
+++ b/src/main/kotlin/it/pagopa/wallet/exceptionhandler/ExceptionHandler.kt
@@ -5,10 +5,7 @@ import it.pagopa.generated.wallet.model.WalletApplicationDto
 import it.pagopa.generated.wallet.model.WalletApplicationStatusDto
 import it.pagopa.generated.wallet.model.WalletApplicationsPartialUpdateDto
 import it.pagopa.wallet.common.tracing.WalletTracing
-import it.pagopa.wallet.exception.ApiError
-import it.pagopa.wallet.exception.MigrationError
-import it.pagopa.wallet.exception.RestApiException
-import it.pagopa.wallet.exception.WalletApplicationStatusConflictException
+import it.pagopa.wallet.exception.*
 import jakarta.xml.bind.ValidationException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -152,6 +149,15 @@ class ExceptionHandler(private val walletTracing: WalletTracing) {
                     .title("Wallet delete")
                     .detail("Cannot migrate a deleted wallet ${e.walletId.value}")
         }.let { ResponseEntity.status(it.status).body(it) }
+
+    /** Handler for wallet already deleted exception */
+    @ExceptionHandler(WalletAlreadyDeletedException::class)
+    fun handleWalletAlreadyDeletedException(
+        e: WalletAlreadyDeletedException
+    ): ResponseEntity<Void> {
+        logger.error("Exception processing the request", e)
+        return ResponseEntity.noContent().build()
+    }
 
     private fun traceInvalidRequest(request: ServerHttpRequest) {
         val contextPath: String = request.path.value()

--- a/src/main/kotlin/it/pagopa/wallet/services/WalletService.kt
+++ b/src/main/kotlin/it/pagopa/wallet/services/WalletService.kt
@@ -816,6 +816,8 @@ class WalletService(
         walletRepository
             .findByIdAndUserId(walletId.value.toString(), userId.id.toString())
             .switchIfEmpty { Mono.error(WalletNotFoundException(walletId)) }
+            .filter { it.status != WalletStatusDto.DELETED.toString() }
+            .switchIfEmpty { Mono.error(WalletAlreadyDeletedException(walletId)) }
             .flatMap { walletRepository.save(it.copy(status = WalletStatusDto.DELETED.toString())) }
             .map { LoggedAction(Unit, WalletDeletedEvent(walletId.value.toString())) }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Delete api does not update entities if wallet is already deleted, it just returns 204 instead (as if deleted for the first time)
<!--- Describe your changes in detail -->

#### Motivation and Context
Permitting deletion on wallets already in deleted status caused multiple records related to deletion process to be written in payment-wallets-log-events and wallets in payment-wallets to be updated more than once.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Delet api tested with new jUnit tests and Postman suites
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
